### PR TITLE
[Feat] #2 OAuth2 로그인 엔드포인트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	//docs
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/woodada/common/auth/adapter/in/OAuth2LoginController.java
+++ b/src/main/java/com/woodada/common/auth/adapter/in/OAuth2LoginController.java
@@ -1,0 +1,33 @@
+package com.woodada.common.auth.adapter.in;
+
+import com.woodada.common.auth.adapter.in.response.AccessTokenResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/oauth2")
+public class OAuth2LoginController {
+
+    @GetMapping("/{providerType}")
+    ResponseEntity<AccessTokenResponse> callBack(
+        @PathVariable("providerType") String providerType,
+        @RequestParam("code") String code
+    ) {
+        //todo 인증, 토큰발급 개발
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", "refresh_token")
+            .maxAge(1800)
+            .httpOnly(true)
+            .path("/")
+            .build();
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+            .body(new AccessTokenResponse("access_token"));
+    }
+}

--- a/src/main/java/com/woodada/common/auth/adapter/in/response/AccessTokenResponse.java
+++ b/src/main/java/com/woodada/common/auth/adapter/in/response/AccessTokenResponse.java
@@ -1,0 +1,6 @@
+package com.woodada.common.auth.adapter.in.response;
+
+public record AccessTokenResponse(
+    String accessToken
+) {
+}


### PR DESCRIPTION
## 📍 이슈 번호
#2


## 📚 작업 내용
OAuth2 로그인 api 문서 전달을 위해 엔드포인트 요청, 응답 규격만 미리 작성하였습니다. 