### PR TITLE
[Feat, Test] #12 성공 응답 시 ErrorResponse 입력 방지

### DIFF
--- a/src/main/java/com/woodada/common/support/ApiResponse.java
+++ b/src/main/java/com/woodada/common/support/ApiResponse.java
@@ -26,6 +26,8 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<T> success(final T data) {
+        assert !(data instanceof ErrorResponse): "ErrorResponse는 입력할 수 없습니다.";
+
         return new ApiResponse<>(ResultCode.SUCCESS, data, null);
     }
 

--- a/src/test/java/com/woodada/common/support/ApiResponseTest.java
+++ b/src/test/java/com/woodada/common/support/ApiResponseTest.java
@@ -1,6 +1,7 @@
 package com.woodada.common.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woodada.common.exception.ErrorResponse;
 import java.util.List;
@@ -29,6 +30,16 @@ class ApiResponseTest {
         assertThat(successWithData.getResult()).isEqualTo(ResultCode.SUCCESS);
         assertThat(successWithData.getData()).isEqualTo(data);
         assertThat(successWithData.getError()).isNull();
+    }
+
+    @DisplayName("success(T data)에 ErrorResponse는 입력 불가")
+    @Test
+    void can_not_pass_an_error_response_to_success() {
+        final ErrorResponse error = ErrorResponse.badRequest(new IllegalArgumentException("예외"));
+
+        assertThatThrownBy(() -> ApiResponse.success(error))
+            .isInstanceOf(AssertionError.class)
+            .hasMessage("ErrorResponse는 입력할 수 없습니다.");
     }
 
     @DisplayName("예외 응답 테스트")


### PR DESCRIPTION
## 📍 이슈 번호
close: #12 


## 📚 작업 내용
* 개발단계에서 ApiResponse.success()에 ErrorResponse를 입력하지 않도록 assert 문 추가
