### PR TITLE
[Feat, Test] #15 refresh token 저장 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ dependencies {
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// Redis
+	implementation ("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation(group: "it.ozimov", name: "embedded-redis", version: "0.7.2")
+
 	// OpenFeign
 	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2022.0.4")
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/src/main/java/com/woodada/common/auth/adapter/out/persistence/MemberJpaEntity.java
+++ b/src/main/java/com/woodada/common/auth/adapter/out/persistence/MemberJpaEntity.java
@@ -10,15 +10,13 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "member")
-@Entity
+@Entity(name = "member")
 public class MemberJpaEntity {
 
     @Id

--- a/src/main/java/com/woodada/common/auth/adapter/out/persistence/RefreshTokenAdapter.java
+++ b/src/main/java/com/woodada/common/auth/adapter/out/persistence/RefreshTokenAdapter.java
@@ -1,0 +1,30 @@
+package com.woodada.common.auth.adapter.out.persistence;
+
+import com.woodada.common.auth.application.port.out.RefreshTokenSavePort;
+import com.woodada.common.auth.domain.Token;
+import java.time.Duration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenAdapter implements RefreshTokenSavePort {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public RefreshTokenAdapter(final StringRedisTemplate stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
+
+    @Override
+    public void save(final Long memberId, final String refreshToken) {
+        final String key = String.format("member::%d::string::refresh_token", memberId);
+
+        try {
+            stringRedisTemplate.opsForSet().add(key, refreshToken);
+            stringRedisTemplate.expire(key, Duration.ofSeconds(Token.REFRESH_TOKEN_EXPIRATION_PERIOD));
+        } catch(Exception e) {
+            //todo 레디스 저장 도중 발생 가능한 예외 종류와 그에 대한 처리?
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/woodada/common/auth/application/port/out/RefreshTokenSavePort.java
+++ b/src/main/java/com/woodada/common/auth/application/port/out/RefreshTokenSavePort.java
@@ -1,0 +1,6 @@
+package com.woodada.common.auth.application.port.out;
+
+public interface RefreshTokenSavePort {
+
+    void save(Long memberId, String refreshToken);
+}

--- a/src/test/java/com/woodada/common/IntegrationTestBase.java
+++ b/src/test/java/com/woodada/common/IntegrationTestBase.java
@@ -1,0 +1,21 @@
+package com.woodada.common;
+
+import com.woodada.common.annotation.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+public abstract class IntegrationTestBase {
+
+    @Autowired
+    private RDBInitialization rdbInitialization;
+
+    @Autowired
+    private RedisInitialization redisInitialization;
+
+    @AfterEach
+    void afterEach() {
+        rdbInitialization.truncateAllEntity();
+        redisInitialization.initRedis();
+    }
+}

--- a/src/test/java/com/woodada/common/RDBInitialization.java
+++ b/src/test/java/com/woodada/common/RDBInitialization.java
@@ -1,0 +1,57 @@
+package com.woodada.common;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.Metamodel;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RDBInitialization {
+
+    private static final String SET_FOREIGN_KEY_CHECKS_FALSE = "SET FOREIGN_KEY_CHECKS = 0";
+    private static final String SET_FOREIGN_KEY_CHECKS_TRUE = "SET FOREIGN_KEY_CHECKS = 1";
+
+    private final EntityManager entityManager;
+    private Set<String> tableNames;
+
+    @PostConstruct
+    public void afterPropertiesSet() {
+        Metamodel metamodel = entityManager.getMetamodel();
+        tableNames = metamodel.getEntities().stream()
+                .filter(isEntityTypeAndNotNull())
+                .map(changeToLowerCase())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private Predicate<EntityType<?>> isEntityTypeAndNotNull() {
+        return entityType -> entityType.getJavaType().getAnnotation(Entity.class) != null;
+    }
+
+    private Function<EntityType<?>, String> changeToLowerCase() {
+        return entityType -> entityType.getName().toLowerCase();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void truncateAllEntity() {
+        entityManager.flush();
+        entityManager.clear();
+
+        entityManager.createNativeQuery(SET_FOREIGN_KEY_CHECKS_FALSE).executeUpdate();
+
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+        }
+
+        entityManager.createNativeQuery(SET_FOREIGN_KEY_CHECKS_TRUE).executeUpdate();
+    }
+}

--- a/src/test/java/com/woodada/common/RedisInitialization.java
+++ b/src/test/java/com/woodada/common/RedisInitialization.java
@@ -1,0 +1,24 @@
+package com.woodada.common;
+
+import java.util.Set;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisInitialization {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public RedisInitialization(final RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void initRedis() {
+        final Set<String> keys = redisTemplate.keys("*");
+
+        for (String key : keys) {
+            redisTemplate.delete(key);
+        }
+    }
+}
+

--- a/src/test/java/com/woodada/common/annotation/IntegrationTest.java
+++ b/src/test/java/com/woodada/common/annotation/IntegrationTest.java
@@ -1,0 +1,18 @@
+package com.woodada.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@Inherited
+@SpringBootTest
+@ActiveProfiles("test")
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IntegrationTest {
+
+}

--- a/src/test/java/com/woodada/common/config/EmbeddedRedisConfiguration.java
+++ b/src/test/java/com/woodada/common/config/EmbeddedRedisConfiguration.java
@@ -15,7 +15,7 @@ import redis.embedded.RedisServer;
 @ActiveProfiles("test")
 public class EmbeddedRedisConfiguration {
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int port;
     private RedisServer redisServer;
 

--- a/src/test/java/com/woodada/common/config/EmbeddedRedisConfiguration.java
+++ b/src/test/java/com/woodada/common/config/EmbeddedRedisConfiguration.java
@@ -1,0 +1,69 @@
+package com.woodada.common.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.StringUtils;
+import redis.embedded.RedisServer;
+
+@Configuration
+@ActiveProfiles("test")
+public class EmbeddedRedisConfiguration {
+
+    @Value("${spring.redis.port}")
+    private int port;
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        redisServer = new RedisServer(isRunning() ? findAvailablePort() : port);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    private boolean isRunning() throws IOException {
+        return isRunning(executeGrepProcessCommand(port));
+    }
+
+    public int findAvailablePort() throws IOException {
+        for (int port = 10000; port <= 65535; port++) {
+            Process process = executeGrepProcessCommand(port);
+            if (!isRunning(process)) {
+                return port;
+            }
+        }
+        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+    }
+
+    private Process executeGrepProcessCommand(int port) throws IOException {
+        String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    private boolean isRunning(Process process) {
+        String line;
+        StringBuilder pidInfo = new StringBuilder();
+
+        try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            while ((line = input.readLine()) != null) {
+                pidInfo.append(line);
+            }
+        } catch (Exception e) {
+        }
+
+        return StringUtils.hasText(pidInfo.toString());
+    }
+
+}

--- a/src/test/java/com/woodada/test/auth/helper/OAuth2AccessTokenRequestTestImpl.java
+++ b/src/test/java/com/woodada/test/auth/helper/OAuth2AccessTokenRequestTestImpl.java
@@ -1,0 +1,18 @@
+package com.woodada.test.auth.helper;
+
+
+import com.woodada.common.auth.application.port.out.OAuth2AccessTokenRequestPort;
+import com.woodada.common.auth.domain.OAuth2AccessToken;
+import com.woodada.common.auth.domain.ProviderType;
+
+/**
+ * LoginRefreshToken 테스트용 구현체
+ */
+//todo 테스트용 구현체 만드는 거 좋긴 한데 인터페이스 구현 메서드 따라가기 단축키 눌렀을 때 테스트 클래스도 목록에 뜨는 게 좀 불편.. 다음엔 mock 써보기
+public class OAuth2AccessTokenRequestTestImpl implements OAuth2AccessTokenRequestPort {
+
+    @Override
+    public OAuth2AccessToken requestOAuth2AccessToken(ProviderType providerType, String authCode) {
+        return new OAuth2AccessToken("access_token....", "Bearer");
+    }
+}

--- a/src/test/java/com/woodada/test/auth/helper/OAuth2MockConfiguration.java
+++ b/src/test/java/com/woodada/test/auth/helper/OAuth2MockConfiguration.java
@@ -1,0 +1,26 @@
+package com.woodada.test.auth.helper;
+
+import com.woodada.common.auth.application.port.out.OAuth2AccessTokenRequestPort;
+import com.woodada.common.auth.application.port.out.OAuth2UserInfoRequestPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class OAuth2MockConfiguration {
+
+    @Profile("test")
+    @Bean
+    @Primary
+    public OAuth2AccessTokenRequestPort oAuth2AccessTokenRequestPort() {
+        return new OAuth2AccessTokenRequestTestImpl();
+    }
+
+    @Profile("test")
+    @Bean
+    @Primary
+    public OAuth2UserInfoRequestPort oAuth2UserInfoRequestPort() {
+        return new OAuth2UserInfoRequestPortTestImpl();
+    }
+}

--- a/src/test/java/com/woodada/test/auth/helper/OAuth2UserInfoRequestPortTestImpl.java
+++ b/src/test/java/com/woodada/test/auth/helper/OAuth2UserInfoRequestPortTestImpl.java
@@ -1,0 +1,17 @@
+package com.woodada.test.auth.helper;
+
+import com.woodada.common.auth.application.port.out.OAuth2UserInfoRequestPort;
+import com.woodada.common.auth.domain.OAuth2AccessToken;
+import com.woodada.common.auth.domain.OAuth2UserInfo;
+import com.woodada.common.auth.domain.ProviderType;
+
+/**
+ * LoginRefreshToken 테스트용 구현체
+ */
+public class OAuth2UserInfoRequestPortTestImpl implements OAuth2UserInfoRequestPort {
+
+    @Override
+    public OAuth2UserInfo requestOAuth2UserInfo(ProviderType providerType, OAuth2AccessToken accessToken) {
+        return new OAuth2UserInfo("test@email.com", "테스트유저", "profile_url.png");
+    }
+}

--- a/src/test/java/com/woodada/test/auth/integrationtest/LoginRefreshTokenTest.java
+++ b/src/test/java/com/woodada/test/auth/integrationtest/LoginRefreshTokenTest.java
@@ -1,0 +1,29 @@
+package com.woodada.test.auth.integrationtest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woodada.common.IntegrationTestBase;
+import com.woodada.common.auth.application.port.in.OAuth2LoginUseCase;
+import com.woodada.common.auth.domain.ProviderType;
+import com.woodada.common.auth.domain.Token;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@DisplayName("[IntegrationTest] Refresh Token 저장 테스트")
+public class LoginRefreshTokenTest extends IntegrationTestBase {
+
+    @Autowired private StringRedisTemplate redisTemplate;
+    @Autowired private OAuth2LoginUseCase oAuth2LoginUseCase;
+
+    @Test
+    @DisplayName("로그인에 성공하면 레디스에 리프레시 토큰이 저장된다.")
+    void login() {
+        final Token token = oAuth2LoginUseCase.login(ProviderType.GOOGLE, "auth_code....");
+        final String refreshTokenSaveKey = "member::1::string::refresh_token";
+
+        assertThat(redisTemplate.opsForSet().pop(refreshTokenSaveKey))
+            .isEqualTo(token.refreshToken());
+    }
+}

--- a/src/test/java/com/woodada/test/common/exception/ExceptionTestController.java
+++ b/src/test/java/com/woodada/test/common/exception/ExceptionTestController.java
@@ -1,5 +1,6 @@
-package com.woodada.common.exception;
+package com.woodada.test.common.exception;
 
+import com.woodada.common.exception.WddException;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;

--- a/src/test/java/com/woodada/test/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/woodada/test/common/exception/GlobalExceptionHandlerTest.java
@@ -1,4 +1,4 @@
-package com.woodada.common.exception;
+package com.woodada.test.common.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -9,7 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woodada.common.exception.ExceptionTestController.TestRequestBody;
+import com.woodada.test.common.exception.ExceptionTestController.TestRequestBody;
+import com.woodada.common.exception.WddException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woodada/test/common/exception/TestException.java
+++ b/src/test/java/com/woodada/test/common/exception/TestException.java
@@ -1,5 +1,6 @@
-package com.woodada.common.exception;
+package com.woodada.test.common.exception;
 
+import com.woodada.common.exception.BaseExceptionType;
 import org.springframework.http.HttpStatus;
 
 enum TestException implements BaseExceptionType {

--- a/src/test/java/com/woodada/test/common/support/ApiResponseTest.java
+++ b/src/test/java/com/woodada/test/common/support/ApiResponseTest.java
@@ -1,9 +1,11 @@
-package com.woodada.common.support;
+package com.woodada.test.common.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woodada.common.exception.ErrorResponse;
+import com.woodada.common.support.ApiResponse;
+import com.woodada.common.support.ResultCode;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 📍 이슈 번호
#15


## 📚 작업 내용
* 통합테스트 시 RDB, Redis 초기화 설정
* 레디스에 리프레시 토큰 저장 구현 및 테스트