### PR TITLE
[30-33] 일기 수정 api 구현

### DIFF
--- a/src/main/java/com/woodada/common/auth/adapter/out/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/com/woodada/common/auth/adapter/out/persistence/MemberPersistenceAdapter.java
@@ -24,7 +24,7 @@ public class MemberPersistenceAdapter implements MemberQueryPort, MemberRegister
         }
 
         final MemberJpaEntity foundMember = optionalMember.get();
-        return Optional.ofNullable(foundMember.toDomainEntity());
+        return Optional.of(foundMember.toDomainEntity());
     }
 
     @Override

--- a/src/main/java/com/woodada/common/auth/argument_resolver/WddMemberResolver.java
+++ b/src/main/java/com/woodada/common/auth/argument_resolver/WddMemberResolver.java
@@ -4,10 +4,12 @@ import com.woodada.common.auth.adapter.out.persistence.MemberJpaEntity;
 import com.woodada.common.auth.adapter.out.persistence.MemberRepository;
 import com.woodada.common.auth.domain.Deleted;
 import com.woodada.common.auth.exception.AuthenticationException;
+import com.woodada.common.config.jpa.AuditorAwareImpl;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -19,9 +21,11 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 public class WddMemberResolver implements HandlerMethodArgumentResolver {
 
     private final MemberRepository memberRepository;
+    private final AuditorAwareImpl auditorAware;
 
-    public WddMemberResolver(final MemberRepository memberRepository) {
+    public WddMemberResolver(final MemberRepository memberRepository, final AuditorAware auditorAware) {
         this.memberRepository = memberRepository;
+        this.auditorAware = (AuditorAwareImpl) auditorAware;
     }
 
     @Override
@@ -44,6 +48,10 @@ public class WddMemberResolver implements HandlerMethodArgumentResolver {
         }
 
         final MemberJpaEntity authMember = optionalMember.get();
+
+        //todo 다이어리 crud 끝나고 시큐리티 적용한 후에 제거..
+        auditorAware.setCurrentAuditor(authMember.getId());
+
         return new WddMember(
             authMember.getId(),
             authMember.getEmail(),

--- a/src/main/java/com/woodada/common/config/jpa/AuditorAwareImpl.java
+++ b/src/main/java/com/woodada/common/config/jpa/AuditorAwareImpl.java
@@ -5,9 +5,16 @@ import org.springframework.data.domain.AuditorAware;
 
 public class AuditorAwareImpl implements AuditorAware<Long> {
 
+    private Long memberId = 0L;
+
     @Override
     public Optional<Long> getCurrentAuditor() {
         //todo spring security
-        return Optional.of(0L);
+        return Optional.of(memberId);
+    }
+
+    //todo 다이어리 crud 끝내고 시큐리티 적용..
+    public void setCurrentAuditor(Long memberId) {
+        this.memberId = memberId;
     }
 }

--- a/src/main/java/com/woodada/core/diary/adapter/in/DiaryModifyAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/DiaryModifyAdapter.java
@@ -1,0 +1,32 @@
+package com.woodada.core.diary.adapter.in;
+
+import com.woodada.common.auth.argument_resolver.WddMember;
+import com.woodada.common.support.ApiResponse;
+import com.woodada.core.diary.adapter.in.request.DiaryModifyRequest;
+import com.woodada.core.diary.application.port.in.DiaryModifyCommand;
+import com.woodada.core.diary.application.port.in.DiaryModifyUseCase;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/diary")
+public class DiaryModifyAdapter {
+
+    private final DiaryModifyUseCase diaryModifyUseCase;
+
+    public DiaryModifyAdapter(final DiaryModifyUseCase diaryModifyUseCase) {
+        this.diaryModifyUseCase = diaryModifyUseCase;
+    }
+
+    @PutMapping
+    ResponseEntity<ApiResponse<Void>> modifyDiary(WddMember wddMember, @RequestBody @Valid DiaryModifyRequest request) {
+        final DiaryModifyCommand command = new DiaryModifyCommand(request.getId(), request.getTitle(), request.getContents());
+        diaryModifyUseCase.modify(wddMember, command);
+
+        return ResponseEntity.ok(ApiResponse.OK);
+    }
+}

--- a/src/main/java/com/woodada/core/diary/adapter/in/request/DiaryModifyRequest.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/request/DiaryModifyRequest.java
@@ -1,0 +1,24 @@
+package com.woodada.core.diary.adapter.in.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiaryModifyRequest {
+
+    @NotNull
+    private Long id;
+
+    @NotBlank
+    @Size(min = 1, max = 100)
+    private String title;
+
+    @NotBlank
+    @Size(min = 1, max = 5000)
+    private String contents;
+}

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
@@ -5,6 +5,7 @@ import com.woodada.core.diary.application.port.out.DiarySavePort;
 import com.woodada.core.diary.domain.Diary;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,6 +20,17 @@ public class DiaryPersistenceAdapter implements DiaryFindPort, DiarySavePort {
     @Override
     public boolean existsDiary(final Long createdBy, final LocalDate writeDate) {
         return diaryRepository.existsByCreatedByAndCreatedAtBetween(createdBy, writeDate.atStartOfDay(), writeDate.atTime(LocalTime.MAX));
+    }
+
+    @Override
+    public Optional<Diary> findDiary(final Long id, final Long createdBy) {
+        final Optional<DiaryJpaEntity> optionalDiary = diaryRepository.findByIdAndCreatedBy(id, createdBy);
+        if (optionalDiary.isEmpty()) {
+            return Optional.empty();
+        }
+
+        final DiaryJpaEntity foundDiary = optionalDiary.get();
+        return Optional.of(foundDiary.toDomainEntity());
     }
 
     @Override

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryRepository.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryRepository.java
@@ -1,9 +1,12 @@
 package com.woodada.core.diary.adapter.out.persistence;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DiaryRepository extends JpaRepository<DiaryJpaEntity, Long> {
 
     boolean existsByCreatedByAndCreatedAtBetween(Long createdBy, LocalDateTime startOfDate, LocalDateTime endOfDate);
+
+    Optional<DiaryJpaEntity> findByIdAndCreatedBy(Long id, Long createdBy);
 }

--- a/src/main/java/com/woodada/core/diary/application/port/in/DiaryModifyCommand.java
+++ b/src/main/java/com/woodada/core/diary/application/port/in/DiaryModifyCommand.java
@@ -1,0 +1,24 @@
+package com.woodada.core.diary.application.port.in;
+
+import org.springframework.util.ObjectUtils;
+
+public record DiaryModifyCommand(
+    Long id,
+    String title,
+    String contents
+) {
+
+    public DiaryModifyCommand {
+        if (ObjectUtils.isEmpty(id)) {
+            throw new IllegalArgumentException("수정할 일기 id를 입력해 주세요.");
+        }
+
+        if (ObjectUtils.isEmpty(title) || title.length() < 1) {
+            throw new IllegalArgumentException("일기 제목을 한 글자 이상 입력해 주세요.");
+        }
+
+        if (ObjectUtils.isEmpty(contents) || contents.length() < 1) {
+            throw new IllegalArgumentException("일기 본문을 한 글자 이상 입력해 주세요.");
+        }
+    }
+}

--- a/src/main/java/com/woodada/core/diary/application/port/in/DiaryModifyUseCase.java
+++ b/src/main/java/com/woodada/core/diary/application/port/in/DiaryModifyUseCase.java
@@ -1,0 +1,16 @@
+package com.woodada.core.diary.application.port.in;
+
+import com.woodada.common.auth.argument_resolver.WddMember;
+
+public interface DiaryModifyUseCase {
+
+    /**
+     * 일기를 수정한다
+     *
+     * @param wddMember 인증된 멤버 정보
+     * @param command   일기 수정 정보
+     * @throws com.woodada.common.exception.WddException 일기가 조회되지 않은 경우
+     * @throws IllegalArgumentException                  입력 값이 유효 범위를 위반한 경우
+     */
+    void modify(WddMember wddMember, DiaryModifyCommand command);
+}

--- a/src/main/java/com/woodada/core/diary/application/port/out/DiaryFindPort.java
+++ b/src/main/java/com/woodada/core/diary/application/port/out/DiaryFindPort.java
@@ -1,6 +1,8 @@
 package com.woodada.core.diary.application.port.out;
 
+import com.woodada.core.diary.domain.Diary;
 import java.time.LocalDate;
+import java.util.Optional;
 
 public interface DiaryFindPort {
 
@@ -12,4 +14,13 @@ public interface DiaryFindPort {
      * @return 일기 존재 여부
      */
     boolean existsDiary(Long createdBy, LocalDate writeDate);
+
+    /**
+     * 일기를 조회한다.
+     *
+     * @param id        일기 id
+     * @param createdBy 작성자 id
+     * @return 일기
+     */
+    Optional<Diary> findDiary(Long id, Long createdBy);
 }

--- a/src/main/java/com/woodada/core/diary/application/service/DiaryModifyService.java
+++ b/src/main/java/com/woodada/core/diary/application/service/DiaryModifyService.java
@@ -1,0 +1,32 @@
+package com.woodada.core.diary.application.service;
+
+import com.woodada.common.auth.argument_resolver.WddMember;
+import com.woodada.common.exception.WddException;
+import com.woodada.core.diary.application.port.in.DiaryModifyCommand;
+import com.woodada.core.diary.application.port.in.DiaryModifyUseCase;
+import com.woodada.core.diary.application.port.out.DiaryFindPort;
+import com.woodada.core.diary.application.port.out.DiarySavePort;
+import com.woodada.core.diary.domain.Diary;
+import com.woodada.core.diary.domain.DiaryException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DiaryModifyService implements DiaryModifyUseCase {
+
+    private final DiaryFindPort diaryFindPort;
+    private final DiarySavePort diarySavePort;
+
+    public DiaryModifyService(final DiaryFindPort diaryFindPort, final DiarySavePort diarySavePort) {
+        this.diaryFindPort = diaryFindPort;
+        this.diarySavePort = diarySavePort;
+    }
+
+    @Override
+    public void modify(final WddMember wddMember, final DiaryModifyCommand command) {
+        final Diary diary = diaryFindPort.findDiary(command.id(), wddMember.getId())
+            .orElseThrow(() -> new WddException(DiaryException.NONE_CONTENTS));
+
+        diary.modify(command.title(), command.contents());
+        diarySavePort.saveDiary(diary);
+    }
+}

--- a/src/main/java/com/woodada/core/diary/domain/Diary.java
+++ b/src/main/java/com/woodada/core/diary/domain/Diary.java
@@ -1,13 +1,14 @@
 package com.woodada.core.diary.domain;
 
 import lombok.Getter;
+import org.springframework.util.ObjectUtils;
 
 @Getter
 public class Diary {
 
     private final Long id;
-    private final String title;
-    private final String contents;
+    private String title;
+    private String contents;
 
     private Diary(final Long id, final String title, final String contents) {
         this.id = id;
@@ -18,23 +19,52 @@ public class Diary {
     /**
      * DB 저장 전 일기 인스턴스를 생성한다
      *
-     * @param title 제목
+     * @param title    제목
      * @param contents 본문
      * @return 저장되지 않은 Diary
+     * @throws IllegalArgumentException 생성할 일기 제목, 본문을 null 또는 한 글자 미만으로 입력한 경우
      */
     public static Diary withoutId(final String title, final String contents) {
+        if (ObjectUtils.isEmpty(title) || title.length() < 1) {
+            throw new IllegalArgumentException("일기 제목을 한 글자 이상 입력해 주세요.");
+        }
+
+        if (ObjectUtils.isEmpty(contents) || contents.length() < 1) {
+            throw new IllegalArgumentException("일기 본문을 한 글자 이상 입력해 주세요.");
+        }
+
         return new Diary(null, title, contents);
     }
 
     /**
      * DB에서 조회된 일기 인스턴스를 생성한다
      *
-     * @param id diary id
-     * @param title 제목
+     * @param id       diary id
+     * @param title    제목
      * @param contents 본문
      * @return 조회된 Diary
      */
     public static Diary withId(final Long id, final String title, final String contents) {
         return new Diary(id, title, contents);
+    }
+
+    /**
+     * 일기를 수정한다
+     *
+     * @param title    제목
+     * @param contents 본문
+     * @throws IllegalArgumentException 수정할 일기 제목, 본문을 null 또는 한 글자 미만으로 입력한 경우
+     */
+    public void modify(final String title, final String contents) {
+        if (ObjectUtils.isEmpty(title) || title.length() < 1) {
+            throw new IllegalArgumentException("수정할 제목을 한 글자 이상 입력해 주세요.");
+        }
+
+        if (ObjectUtils.isEmpty(contents) || contents.length() < 1) {
+            throw new IllegalArgumentException("수정할 본문을 한 글자 이상 입력해 주세요.");
+        }
+
+        this.title = title;
+        this.contents = contents;
     }
 }

--- a/src/main/java/com/woodada/core/diary/domain/DiaryException.java
+++ b/src/main/java/com/woodada/core/diary/domain/DiaryException.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum DiaryException implements BaseExceptionType {
 
-    DUPLICATED_WRITE_DATE("400", "오늘 작성한 일기가 존재합니다.", HttpStatus.BAD_REQUEST);
+    DUPLICATED_WRITE_DATE("400", "오늘 작성한 일기가 존재합니다.", HttpStatus.BAD_REQUEST),
+    NONE_CONTENTS("400", "일기가 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
 
     String code;
     String message;

--- a/src/test/java/com/woodada/core/diary/adapter/in/DiaryModifyAcceptanceTest.java
+++ b/src/test/java/com/woodada/core/diary/adapter/in/DiaryModifyAcceptanceTest.java
@@ -1,0 +1,161 @@
+package com.woodada.core.diary.adapter.in;
+
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.woodada.common.auth.adapter.out.persistence.MemberJpaEntity;
+import com.woodada.common.auth.adapter.out.persistence.MemberRepository;
+import com.woodada.common.auth.argument_resolver.MemberHelper;
+import com.woodada.common.auth.domain.Deleted;
+import com.woodada.common.auth.domain.JwtHandler;
+import com.woodada.common.auth.domain.Token;
+import com.woodada.common.auth.domain.UserRole;
+import com.woodada.common.config.jpa.AuditorAwareImpl;
+import com.woodada.core.diary.adapter.in.request.DiaryModifyRequest;
+import com.woodada.core.diary.adapter.out.persistence.DiaryJpaEntity;
+import com.woodada.core.diary.adapter.out.persistence.DiaryRepository;
+import com.woodada.core.diary.domain.Diary;
+import com.woodada.test_helper.AcceptanceTestBase;
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.http.HttpHeaders;
+
+@DisplayName("[acceptance test] 다이어리 수정 인수 테스트")
+class DiaryModifyAcceptanceTest extends AcceptanceTestBase {
+
+    @Autowired private JwtHandler jwtHandler;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private DiaryRepository diaryRepository;
+    @Autowired private AuditorAware<Long> auditorAware;
+
+    @DisplayName("인증된 멤버가 유효한 일기 제목, 본문을 입력 후 저장을 요청하면 수정에 성공한다.")
+    @Test
+    void when_valid_content_then_diary_saved() throws JsonProcessingException {
+        saveMember(1L);
+        ((AuditorAwareImpl) auditorAware).setCurrentAuditor(1L); // todo 다이어리 CRUD 끝나고 제거..
+        saveDiary("최초 저장 제목", "최초 저장 본문");
+
+        given()
+            .contentType(ContentType.JSON)
+            .header(getAuthHeader(1L))
+            .body(objectMapper.readValue("""
+                {
+                    "id": 1,
+                    "title": "수정 일기 제목",
+                    "contents": "수정 일기 본문"
+                }
+                """, DiaryModifyRequest.class))
+
+            .when()
+            .put("/api/v1/diary")
+
+            .then()
+            .statusCode(200)
+            .body("success", equalTo(true))
+            .body("data", nullValue())
+            .body("error", nullValue())
+            .log().all();
+
+        List<DiaryJpaEntity> diaries = diaryRepository.findAll();
+
+        assertThat(diaries.get(0).getTitle()).isEqualTo("수정 일기 제목");
+        assertThat(diaries.get(0).getContents()).isEqualTo("수정 일기 본문");
+    }
+
+    @DisplayName("일기 본문이 5000자를 초과하면 수정에 실패한다.")
+    @Test
+    void when_contents_size_over_5000_then_throw_exception() throws JsonProcessingException {
+        saveMember(1L);
+
+        String titleOver100 = String.format("""
+                {
+                    "id": 1,
+                    "title": "일기 제목",
+                    "contents": "%s"
+                }
+                """, "T".repeat(5001));
+
+        given()
+            .contentType(ContentType.JSON)
+            .header(getAuthHeader(1L))
+            .body(objectMapper.readValue(titleOver100, DiaryModifyRequest.class))
+
+            .when()
+            .post("/api/v1/diary")
+
+            .then()
+            .statusCode(400)
+            .body("success", equalTo(false))
+            .body("data", nullValue())
+            .body("error.code", equalTo("400"))
+            .body("error.message", equalTo("입력 조건을 위반하였습니다."))
+            .body("error.validations.size()", equalTo(1))
+            .body("error.validations.field", everyItem(is("contents")))
+            .body("error.validations.message", everyItem(is("크기가 1에서 5000 사이여야 합니다")))
+            .body("error.validations.value", everyItem(is("T".repeat(5001))))
+            .log().all();
+    }
+
+    @DisplayName("일기 제목이 100자를 초과하면 수정에 실패한다.")
+    @Test
+    void when_title_size_over_100_then_throw_exception() throws JsonProcessingException {
+        saveMember(1L);
+
+        String titleOver100 = String.format("""
+                {
+                    "id": 1,
+                    "title": "%s",
+                    "contents": "일기 본문"
+                }
+                """, "T".repeat(101));
+
+        given()
+            .contentType(ContentType.JSON)
+            .header(getAuthHeader(1L))
+            .body(objectMapper.readValue(titleOver100, DiaryModifyRequest.class))
+
+            .when()
+            .put("/api/v1/diary")
+
+            .then()
+            .statusCode(400)
+            .body("success", equalTo(false))
+            .body("data", nullValue())
+            .body("error.code", equalTo("400"))
+            .body("error.message", equalTo("입력 조건을 위반하였습니다."))
+            .body("error.validations.size()", equalTo(1))
+            .body("error.validations.field", everyItem(is("title")))
+            .body("error.validations.message", everyItem(is("크기가 1에서 100 사이여야 합니다")))
+            .body("error.validations.value", everyItem(is("T".repeat(101))))
+            .log().all();
+    }
+
+    private Header getAuthHeader(Long memberId) {
+        final String token = "Bearer " + jwtHandler.createToken(memberId, Token.ACCESS_TOKEN_EXPIRATION_PERIOD, Instant.now());
+        return new Header(HttpHeaders.AUTHORIZATION, token);
+    }
+
+    private void saveMember(Long memberId) {
+        MemberJpaEntity memberJpaEntity = MemberHelper.createMemberJpaEntity(memberId, "test@email.com", "테스트유저", "test_profile_url",
+            UserRole.NORMAL, Deleted.FALSE);
+        memberRepository.save(memberJpaEntity);
+    }
+
+    private void saveDiary(String title, String contents) {
+        Diary diary = Diary.withoutId(title, contents);
+        DiaryJpaEntity diaryJpaEntity = DiaryJpaEntity.from(diary);
+        diaryRepository.save(diaryJpaEntity);
+    }
+}

--- a/src/test/java/com/woodada/core/diary/application/port/in/DiaryModifyCommandTest.java
+++ b/src/test/java/com/woodada/core/diary/application/port/in/DiaryModifyCommandTest.java
@@ -1,0 +1,39 @@
+package com.woodada.core.diary.application.port.in;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+@DisplayName("[unit test] DiaryModifyCommand 단위 테스트")
+class DiaryModifyCommandTest {
+
+    @DisplayName("일기 수정 객체의 일기 id에 null을 입력하면 예외가 발생한다.")
+    @Test
+    void given_null_diary_id_then_throw_exception() {
+        Assertions.assertThatThrownBy(() -> new DiaryModifyCommand(null, "제목", "본문"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("수정할 일기 id를 입력해 주세요.");
+    }
+
+
+
+    @DisplayName("일기 수정 객체에 한 글자 미만의 제목을 입력 시 예외가 발생한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void given_title_length_less_than_1_then_throw_exception(String title) {
+        Assertions.assertThatThrownBy(() -> new DiaryModifyCommand(1L, title, "본문"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("일기 제목을 한 글자 이상 입력해 주세요.");
+    }
+
+    @DisplayName("일기 수정 객체에 한 글자 미만의 본문을 입력 시 예외가 발생한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void given_contents_length_less_than_1_then_throw_exception(String contents) {
+        Assertions.assertThatThrownBy(() -> new DiaryModifyCommand(1L, "제목", contents))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("일기 본문을 한 글자 이상 입력해 주세요.");
+    }
+}

--- a/src/test/java/com/woodada/core/diary/domain/DiaryTest.java
+++ b/src/test/java/com/woodada/core/diary/domain/DiaryTest.java
@@ -1,0 +1,44 @@
+package com.woodada.core.diary.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+@DisplayName("[unit test] Diary 단위 테스트")
+public class DiaryTest {
+
+    @DisplayName("일기 수정 시 제목을 한 글자 미만으로 ₩입력하면 예외가 발생한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void given_title_length_less_than_1_when_modify_then_throw_exception(String title) {
+        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문");
+
+        Assertions.assertThatThrownBy(() -> diary.modify(title, "수정 후 본문"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("수정할 제목을 한 글자 이상 입력해 주세요.");
+    }
+
+    @DisplayName("일기 수정 시 본문을 한 글자 미만으로 ₩입력하면 예외가 발생한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void given_contents_length_less_than_1_when_modify_then_throw_exception(String contents) {
+        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문");
+
+        Assertions.assertThatThrownBy(() -> diary.modify("수정 후 제목", contents))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("수정할 본문을 한 글자 이상 입력해 주세요.");
+    }
+
+    @DisplayName("한 글자 이상의 제목과 본문을 전달하면 일기를 수정할 수 있다.")
+    @Test
+    void given_title_and_contents_greater_than_or_equal_to_1_when_modify_then_success() {
+        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문");
+
+        diary.modify("제목", "본문");
+
+        Assertions.assertThat(diary.getTitle()).isEqualTo("제목");
+        Assertions.assertThat(diary.getContents()).isEqualTo("본문");
+    }
+}


### PR DESCRIPTION
## 📍 이슈 번호
#33

## 📚 작업 내용
- 일기 수정 api 구현 및 테스트 코드 추가
- AuditAware Auditing 임시 처리 (ArgumentResolver에서 setter로 직접 세팅. 다이어리 crud 작업 완료 후 스프링 시큐리티 적용해보며 수정 예정)
