### PR TITLE
[30-33] 일기 조회 api 구현

### DIFF
--- a/src/main/java/com/woodada/core/diary/adapter/in/DiaryModifyAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/DiaryModifyAdapter.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/diary")
+@RequestMapping("/api/v1/diaries")
 public class DiaryModifyAdapter {
 
     private final DiaryModifyUseCase diaryModifyUseCase;

--- a/src/main/java/com/woodada/core/diary/adapter/in/DiaryQueryAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/DiaryQueryAdapter.java
@@ -1,10 +1,34 @@
 package com.woodada.core.diary.adapter.in;
 
+import com.woodada.common.auth.argument_resolver.WddMember;
+import com.woodada.common.support.ApiResponse;
+import com.woodada.core.diary.adapter.in.response.DiaryQueryResponse;
+import com.woodada.core.diary.application.port.in.DiaryQueryCommand;
+import com.woodada.core.diary.application.port.in.DiaryQueryUseCase;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/diaries")
 public class DiaryQueryAdapter {
 
+    private final DiaryQueryUseCase diaryQueryUseCase;
+
+    public DiaryQueryAdapter(final DiaryQueryUseCase diaryQueryUseCase) {
+        this.diaryQueryUseCase = diaryQueryUseCase;
+    }
+
+    ResponseEntity<ApiResponse<DiaryQueryResponse>> queryDiaries(
+        WddMember wddMember,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        final DiaryQueryCommand command = new DiaryQueryCommand(startDate, endDate);
+
+        return null;
+    }
 }

--- a/src/main/java/com/woodada/core/diary/adapter/in/DiaryQueryAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/DiaryQueryAdapter.java
@@ -1,0 +1,10 @@
+package com.woodada.core.diary.adapter.in;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/diaries")
+public class DiaryQueryAdapter {
+
+}

--- a/src/main/java/com/woodada/core/diary/adapter/in/DiaryQueryAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/DiaryQueryAdapter.java
@@ -5,9 +5,13 @@ import com.woodada.common.support.ApiResponse;
 import com.woodada.core.diary.adapter.in.response.DiaryQueryResponse;
 import com.woodada.core.diary.application.port.in.DiaryQueryCommand;
 import com.woodada.core.diary.application.port.in.DiaryQueryUseCase;
+import com.woodada.core.diary.domain.Diary;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,13 +26,19 @@ public class DiaryQueryAdapter {
         this.diaryQueryUseCase = diaryQueryUseCase;
     }
 
-    ResponseEntity<ApiResponse<DiaryQueryResponse>> queryDiaries(
+    @GetMapping
+    ResponseEntity<ApiResponse<List<DiaryQueryResponse>>> queryDiaries(
         WddMember wddMember,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
     ) {
         final DiaryQueryCommand command = new DiaryQueryCommand(startDate, endDate);
+        final List<Diary> diaries = diaryQueryUseCase.queryDiaries(wddMember, command);
+        final List<DiaryQueryResponse> response = diaries.stream()
+            .map(DiaryQueryResponse::from)
+            .collect(Collectors.toList());
 
-        return null;
+        final ApiResponse<List<DiaryQueryResponse>> apiResponse = ApiResponse.success(response);
+        return ResponseEntity.ok(apiResponse);
     }
 }

--- a/src/main/java/com/woodada/core/diary/adapter/in/DiaryQueryAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/DiaryQueryAdapter.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,6 +40,15 @@ public class DiaryQueryAdapter {
             .collect(Collectors.toList());
 
         final ApiResponse<List<DiaryQueryResponse>> apiResponse = ApiResponse.success(response);
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @GetMapping("/{id}")
+    ResponseEntity<ApiResponse<DiaryQueryResponse>> queryDiary(WddMember wddMember, @PathVariable Long id) {
+        final Diary diary = diaryQueryUseCase.queryDiary(wddMember, id);
+        final DiaryQueryResponse response = DiaryQueryResponse.from(diary);
+        final ApiResponse<DiaryQueryResponse> apiResponse = ApiResponse.success(response);
+
         return ResponseEntity.ok(apiResponse);
     }
 }

--- a/src/main/java/com/woodada/core/diary/adapter/in/DiaryWriteAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/DiaryWriteAdapter.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/diary")
+@RequestMapping("/api/v1/diaries")
 public class DiaryWriteAdapter {
 
     private final DiaryWriteUseCase diaryWriteUseCase;

--- a/src/main/java/com/woodada/core/diary/adapter/in/response/DiaryQueryResponse.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/response/DiaryQueryResponse.java
@@ -1,0 +1,12 @@
+package com.woodada.core.diary.adapter.in.response;
+
+import java.time.LocalDateTime;
+
+public record DiaryQueryResponse(
+    Long id,
+    String title,
+    String contents,
+    LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/com/woodada/core/diary/adapter/in/response/DiaryQueryResponse.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/response/DiaryQueryResponse.java
@@ -1,12 +1,17 @@
 package com.woodada.core.diary.adapter.in.response;
 
+import com.woodada.core.diary.domain.Diary;
 import java.time.LocalDateTime;
 
 public record DiaryQueryResponse(
     Long id,
     String title,
     String contents,
-    LocalDateTime createdAt
+    LocalDateTime createdAt,
+    LocalDateTime modifiedAt
 ) {
 
+    public static DiaryQueryResponse from(final Diary diary) {
+        return new DiaryQueryResponse(diary.getId(), diary.getTitle(), diary.getContents(), diary.getCreatedAt(), diary.getModifiedAt());
+    }
 }

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryJpaEntity.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryJpaEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,9 +37,12 @@ public class DiaryJpaEntity extends ModifierBaseEntity {
      * DomainEntity to JpaEntity 매핑
      *
      * @param diary 일기 도메인 엔티티
+     * @throws NullPointerException diary에 null이 입력된 경우
      * @return 일기 JPA 엔티티
      */
     public static DiaryJpaEntity from(final Diary diary) {
+        Objects.requireNonNull(diary);
+
         return new DiaryJpaEntity(diary.getId(), diary.getTitle(), diary.getContents());
     }
 

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryJpaEntity.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryJpaEntity.java
@@ -48,6 +48,6 @@ public class DiaryJpaEntity extends ModifierBaseEntity {
      * @return 일기 도메인 엔티티
      */
     public Diary toDomainEntity() {
-        return Diary.withId(this.id, this.title, this.contents);
+        return Diary.withId(id, title, contents, getCreatedBy(), getCreatedAt(), getModifiedBy(), getModifiedAt());
     }
 }

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
@@ -4,8 +4,11 @@ import com.woodada.core.diary.application.port.out.DiaryFindPort;
 import com.woodada.core.diary.application.port.out.DiarySavePort;
 import com.woodada.core.diary.domain.Diary;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -31,6 +34,17 @@ public class DiaryPersistenceAdapter implements DiaryFindPort, DiarySavePort {
 
         final DiaryJpaEntity foundDiary = optionalDiary.get();
         return Optional.of(foundDiary.toDomainEntity());
+    }
+
+    @Override
+    public List<Diary> findAll(final Long createdBy, final LocalDate startDate, final LocalDate endDate) {
+        final LocalDateTime startDateTime = startDate.atStartOfDay();
+        final LocalDateTime endDateTime = endDate.atTime(LocalDateTime.MAX.toLocalTime());
+
+        final List<DiaryJpaEntity> diaryJpaEntities = diaryRepository.findAllByCreatedByAndCreatedAtBetween(createdBy, startDateTime, endDateTime);
+        return diaryJpaEntities.stream()
+            .map(entity -> entity.toDomainEntity())
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
@@ -38,6 +39,10 @@ public class DiaryPersistenceAdapter implements DiaryFindPort, DiarySavePort {
 
     @Override
     public List<Diary> findAll(final Long createdBy, final LocalDate startDate, final LocalDate endDate) {
+        Objects.requireNonNull(createdBy);
+        Objects.requireNonNull(startDate);
+        Objects.requireNonNull(endDate);
+
         final LocalDateTime startDateTime = startDate.atStartOfDay();
         final LocalDateTime endDateTime = endDate.atTime(LocalDateTime.MAX.toLocalTime());
 

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
@@ -23,11 +23,17 @@ public class DiaryPersistenceAdapter implements DiaryFindPort, DiarySavePort {
 
     @Override
     public boolean existsDiary(final Long createdBy, final LocalDate writeDate) {
+        Objects.requireNonNull(createdBy);
+        Objects.requireNonNull(writeDate);
+
         return diaryRepository.existsByCreatedByAndCreatedAtBetween(createdBy, writeDate.atStartOfDay(), writeDate.atTime(LocalTime.MAX));
     }
 
     @Override
     public Optional<Diary> findDiary(final Long id, final Long createdBy) {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(createdBy);
+
         final Optional<DiaryJpaEntity> optionalDiary = diaryRepository.findByIdAndCreatedBy(id, createdBy);
         if (optionalDiary.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
@@ -60,6 +60,8 @@ public class DiaryPersistenceAdapter implements DiaryFindPort, DiarySavePort {
 
     @Override
     public Diary saveDiary(final Diary diary) {
+        Objects.requireNonNull(diary);
+
         final DiaryJpaEntity diaryJpaEntity = DiaryJpaEntity.from(diary);
         final DiaryJpaEntity savedDiary = diaryRepository.save(diaryJpaEntity);
 

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryRepository.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryRepository.java
@@ -1,6 +1,7 @@
 package com.woodada.core.diary.adapter.out.persistence;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface DiaryRepository extends JpaRepository<DiaryJpaEntity, Long> {
     boolean existsByCreatedByAndCreatedAtBetween(Long createdBy, LocalDateTime startOfDate, LocalDateTime endOfDate);
 
     Optional<DiaryJpaEntity> findByIdAndCreatedBy(Long id, Long createdBy);
+
+    List<DiaryJpaEntity> findAllByCreatedByAndCreatedAtBetween(Long createdBy, LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/src/main/java/com/woodada/core/diary/application/port/in/DiaryQueryCommand.java
+++ b/src/main/java/com/woodada/core/diary/application/port/in/DiaryQueryCommand.java
@@ -1,0 +1,24 @@
+package com.woodada.core.diary.application.port.in;
+
+import java.time.LocalDate;
+import org.springframework.util.ObjectUtils;
+
+public record DiaryQueryCommand(
+    LocalDate startDate,
+    LocalDate endDate
+) {
+
+    public DiaryQueryCommand {
+        if (ObjectUtils.isEmpty(startDate)) {
+            throw new IllegalArgumentException("조회 시작 일자를 입력해 주세요.");
+        }
+
+        if (ObjectUtils.isEmpty(endDate)) {
+            throw new IllegalArgumentException("조회 종료 일자를 입력해 주세요.");
+        }
+
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("조회 일자 범위가 유효하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/woodada/core/diary/application/port/in/DiaryQueryUseCase.java
+++ b/src/main/java/com/woodada/core/diary/application/port/in/DiaryQueryUseCase.java
@@ -1,0 +1,17 @@
+package com.woodada.core.diary.application.port.in;
+
+import com.woodada.common.auth.argument_resolver.WddMember;
+import com.woodada.core.diary.domain.Diary;
+import java.util.List;
+
+public interface DiaryQueryUseCase {
+
+    /**
+     * 일기 목록을 조회한다.
+     *
+     * @param wddMember 인증된 멤버 정보
+     * @param command   일기 조회 정보
+     * @return 조회된 일기 목록
+     */
+    List<Diary> queryDiaries(WddMember wddMember, DiaryQueryCommand command);
+}

--- a/src/main/java/com/woodada/core/diary/application/port/in/DiaryQueryUseCase.java
+++ b/src/main/java/com/woodada/core/diary/application/port/in/DiaryQueryUseCase.java
@@ -11,7 +11,18 @@ public interface DiaryQueryUseCase {
      *
      * @param wddMember 인증된 멤버 정보
      * @param command   일기 조회 정보
+     * @throws NullPointerException wddMember, command 중 하나라도 null이 입력된 경우
      * @return 조회된 일기 목록
      */
     List<Diary> queryDiaries(WddMember wddMember, DiaryQueryCommand command);
+
+    /**
+     * 일기를 조회한다.
+     *
+     * @param wddMember 인증된 멤버 정보
+     * @param id        일기 id
+     * @throws NullPointerException wddMember, id 중 하나라도 null이 입력된 경우
+     * @return 조회된 일기
+     */
+    Diary queryDiary(WddMember wddMember, Long id);
 }

--- a/src/main/java/com/woodada/core/diary/application/port/out/DiaryFindPort.java
+++ b/src/main/java/com/woodada/core/diary/application/port/out/DiaryFindPort.java
@@ -2,6 +2,7 @@ package com.woodada.core.diary.application.port.out;
 
 import com.woodada.core.diary.domain.Diary;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface DiaryFindPort {
@@ -23,4 +24,14 @@ public interface DiaryFindPort {
      * @return 일기
      */
     Optional<Diary> findDiary(Long id, Long createdBy);
+
+    /**
+     * 일기 목록을 조회한다.
+     *
+     * @param createdBy 작성자 id
+     * @param startDate 조회 시작 일자
+     * @param endDate 조회 종료 일자
+     * @return 일기 목록
+     */
+    List<Diary> findAll(Long createdBy, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/woodada/core/diary/application/port/out/DiaryFindPort.java
+++ b/src/main/java/com/woodada/core/diary/application/port/out/DiaryFindPort.java
@@ -12,6 +12,7 @@ public interface DiaryFindPort {
      *
      * @param createdBy 작성자 id
      * @param writeDate 일기 작성 일자
+     * @throws NullPointerException createdBy, writeDate 중 하나라도 null이 입력된 경우
      * @return 일기 존재 여부
      */
     boolean existsDiary(Long createdBy, LocalDate writeDate);
@@ -21,6 +22,7 @@ public interface DiaryFindPort {
      *
      * @param id        일기 id
      * @param createdBy 작성자 id
+     * @throws NullPointerException id, createdBy 중 하나라도 null이 입력된 경우
      * @return 일기
      */
     Optional<Diary> findDiary(Long id, Long createdBy);
@@ -31,6 +33,7 @@ public interface DiaryFindPort {
      * @param createdBy 작성자 id
      * @param startDate 조회 시작 일자
      * @param endDate 조회 종료 일자
+     * @throws NullPointerException createdBy, startDate, endDate 중 하나라도 null이 입력된 경우
      * @return 일기 목록
      */
     List<Diary> findAll(Long createdBy, LocalDate startDate, LocalDate endDate);

--- a/src/main/java/com/woodada/core/diary/application/port/out/DiarySavePort.java
+++ b/src/main/java/com/woodada/core/diary/application/port/out/DiarySavePort.java
@@ -8,6 +8,7 @@ public interface DiarySavePort {
      * 일기를 신규 저장한다.
      *
      * @param diary 신규 저장 될 일기
+     * @throws NullPointerException diary에 null이 입력된 경우
      * @return id가 부여된 일기
      */
     Diary saveDiary(Diary diary);

--- a/src/main/java/com/woodada/core/diary/application/service/DiaryQueryService.java
+++ b/src/main/java/com/woodada/core/diary/application/service/DiaryQueryService.java
@@ -1,10 +1,12 @@
 package com.woodada.core.diary.application.service;
 
 import com.woodada.common.auth.argument_resolver.WddMember;
+import com.woodada.common.exception.WddException;
 import com.woodada.core.diary.application.port.in.DiaryQueryCommand;
 import com.woodada.core.diary.application.port.in.DiaryQueryUseCase;
 import com.woodada.core.diary.application.port.out.DiaryFindPort;
 import com.woodada.core.diary.domain.Diary;
+import com.woodada.core.diary.domain.DiaryException;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.stereotype.Service;
@@ -24,5 +26,14 @@ public class DiaryQueryService implements DiaryQueryUseCase {
         Objects.requireNonNull(command);
 
         return diaryFindPort.findAll(wddMember.getId(), command.startDate(), command.endDate());
+    }
+
+    @Override
+    public Diary queryDiary(final WddMember wddMember, final Long id) {
+        Objects.requireNonNull(wddMember);
+        Objects.requireNonNull(id);
+
+        return diaryFindPort.findDiary(id, wddMember.getId())
+            .orElseThrow(() -> new WddException(DiaryException.NONE_CONTENTS));
     }
 }

--- a/src/main/java/com/woodada/core/diary/application/service/DiaryQueryService.java
+++ b/src/main/java/com/woodada/core/diary/application/service/DiaryQueryService.java
@@ -1,0 +1,28 @@
+package com.woodada.core.diary.application.service;
+
+import com.woodada.common.auth.argument_resolver.WddMember;
+import com.woodada.core.diary.application.port.in.DiaryQueryCommand;
+import com.woodada.core.diary.application.port.in.DiaryQueryUseCase;
+import com.woodada.core.diary.application.port.out.DiaryFindPort;
+import com.woodada.core.diary.domain.Diary;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DiaryQueryService implements DiaryQueryUseCase {
+
+    private final DiaryFindPort diaryFindPort;
+
+    public DiaryQueryService(final DiaryFindPort diaryFindPort) {
+        this.diaryFindPort = diaryFindPort;
+    }
+
+    @Override
+    public List<Diary> queryDiaries(final WddMember wddMember, final DiaryQueryCommand command) {
+        Objects.requireNonNull(wddMember);
+        Objects.requireNonNull(command);
+
+        return diaryFindPort.findAll(wddMember.getId(), command.startDate(), command.endDate());
+    }
+}

--- a/src/main/java/com/woodada/core/diary/domain/Diary.java
+++ b/src/main/java/com/woodada/core/diary/domain/Diary.java
@@ -1,5 +1,6 @@
 package com.woodada.core.diary.domain;
 
+import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.util.ObjectUtils;
 
@@ -9,11 +10,27 @@ public class Diary {
     private final Long id;
     private String title;
     private String contents;
+    private Long createdBy;
+    private LocalDateTime createdAt;
+    private Long modifiedBy;
+    private LocalDateTime modifiedAt;
 
-    private Diary(final Long id, final String title, final String contents) {
+    private Diary(
+        final Long id,
+        final String title,
+        final String contents,
+        final Long createdBy,
+        final LocalDateTime createdAt,
+        final Long modifiedBy,
+        final LocalDateTime modifiedAt
+    ) {
         this.id = id;
         this.title = title;
         this.contents = contents;
+        this.createdBy = createdBy;
+        this.createdAt = createdAt;
+        this.modifiedBy = modifiedBy;
+        this.modifiedAt = modifiedAt;
     }
 
     /**
@@ -33,7 +50,7 @@ public class Diary {
             throw new IllegalArgumentException("일기 본문을 한 글자 이상 입력해 주세요.");
         }
 
-        return new Diary(null, title, contents);
+        return new Diary(null, title, contents, null, null, null, null);
     }
 
     /**
@@ -42,10 +59,22 @@ public class Diary {
      * @param id       diary id
      * @param title    제목
      * @param contents 본문
+     * @param createdBy 등록자
+     * @param createdAt 등록 일시
+     * @param modifiedBy 최종 수정자
+     * @param modifiedAt 최종 수정 일시
      * @return 조회된 Diary
      */
-    public static Diary withId(final Long id, final String title, final String contents) {
-        return new Diary(id, title, contents);
+    public static Diary withId(
+        final Long id,
+        final String title,
+        final String contents,
+        final Long createdBy,
+        final LocalDateTime createdAt,
+        final Long modifiedBy,
+        final LocalDateTime modifiedAt
+    ) {
+        return new Diary(id, title, contents, createdBy, createdAt, modifiedBy, modifiedAt);
     }
 
     /**

--- a/src/test/java/com/woodada/core/diary/adapter/in/DiaryModifyAcceptanceTest.java
+++ b/src/test/java/com/woodada/core/diary/adapter/in/DiaryModifyAcceptanceTest.java
@@ -59,7 +59,7 @@ class DiaryModifyAcceptanceTest extends AcceptanceTestBase {
                 """, DiaryModifyRequest.class))
 
             .when()
-            .put("/api/v1/diary")
+            .put("/api/v1/diaries")
 
             .then()
             .statusCode(200)
@@ -93,7 +93,7 @@ class DiaryModifyAcceptanceTest extends AcceptanceTestBase {
             .body(objectMapper.readValue(titleOver100, DiaryModifyRequest.class))
 
             .when()
-            .post("/api/v1/diary")
+            .post("/api/v1/diaries")
 
             .then()
             .statusCode(400)
@@ -127,7 +127,7 @@ class DiaryModifyAcceptanceTest extends AcceptanceTestBase {
             .body(objectMapper.readValue(titleOver100, DiaryModifyRequest.class))
 
             .when()
-            .put("/api/v1/diary")
+            .put("/api/v1/diaries")
 
             .then()
             .statusCode(400)

--- a/src/test/java/com/woodada/core/diary/adapter/in/DiaryQueryAcceptanceTest.java
+++ b/src/test/java/com/woodada/core/diary/adapter/in/DiaryQueryAcceptanceTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.woodada.common.auth.adapter.out.persistence.MemberJpaEntity;
 import com.woodada.common.auth.adapter.out.persistence.MemberRepository;
 import com.woodada.common.auth.argument_resolver.MemberHelper;
@@ -42,7 +41,7 @@ class DiaryQueryAcceptanceTest extends AcceptanceTestBase {
 
     @DisplayName("인증된 멤버가 유효한 조회 시작 일자, 조회 종료 일자를 입력 후 조회를 요청하면 일기 목록 조회에 성공한다.")
     @Test
-    void when_member_is_authned_and_all_parameters_are_valid_then_query_success() throws JsonProcessingException {
+    void when_member_is_authned_and_all_parameters_are_valid_then_query_diaries_success() {
         //given
         saveMember(1L);
         ((AuditorAwareImpl) auditorAware).setCurrentAuditor(1L); // todo 다이어리 CRUD 끝나고 제거..
@@ -67,6 +66,34 @@ class DiaryQueryAcceptanceTest extends AcceptanceTestBase {
             .body("data.contents", everyItem(is("본문")))
             .body("data.createdAt", everyItem(notNullValue(LocalDateTime.class)))
             .body("data.modifiedAt", everyItem(notNullValue(LocalDateTime.class)))
+            .body("error", nullValue())
+            .log().all();
+    }
+
+    @DisplayName("인증된 멤버가 유효한 일기 id를 입력 후 조회를 요청하면 일기 단건 조회에 성공한다.")
+    @Test
+    void when_member_is_authned_and_id_is_valid_then_query_diary_success() {
+        //given
+        saveMember(1L);
+        ((AuditorAwareImpl) auditorAware).setCurrentAuditor(1L); // todo 다이어리 CRUD 끝나고 제거..
+        saveDiary("제목", "본문");
+
+        given()
+            .contentType(ContentType.JSON)
+            .header(getAuthHeader(1L))
+            .pathParam("id", 1L)
+
+        .when()
+            .get("/api/v1/diaries/{id}")
+
+        .then()
+            .statusCode(200)
+            .body("success", equalTo(true))
+            .body("data.id", equalTo(1))
+            .body("data.title", equalTo("제목"))
+            .body("data.contents", equalTo("본문"))
+            .body("data.createdAt", notNullValue(LocalDateTime.class))
+            .body("data.modifiedAt", notNullValue(LocalDateTime.class))
             .body("error", nullValue())
             .log().all();
     }

--- a/src/test/java/com/woodada/core/diary/adapter/in/DiaryQueryAcceptanceTest.java
+++ b/src/test/java/com/woodada/core/diary/adapter/in/DiaryQueryAcceptanceTest.java
@@ -1,0 +1,90 @@
+package com.woodada.core.diary.adapter.in;
+
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.woodada.common.auth.adapter.out.persistence.MemberJpaEntity;
+import com.woodada.common.auth.adapter.out.persistence.MemberRepository;
+import com.woodada.common.auth.argument_resolver.MemberHelper;
+import com.woodada.common.auth.domain.Deleted;
+import com.woodada.common.auth.domain.JwtHandler;
+import com.woodada.common.auth.domain.Token;
+import com.woodada.common.auth.domain.UserRole;
+import com.woodada.common.config.jpa.AuditorAwareImpl;
+import com.woodada.core.diary.adapter.out.persistence.DiaryJpaEntity;
+import com.woodada.core.diary.adapter.out.persistence.DiaryRepository;
+import com.woodada.core.diary.domain.Diary;
+import com.woodada.test_helper.AcceptanceTestBase;
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.http.HttpHeaders;
+
+@DisplayName("[acceptance test] 다이어리 조회 인수 테스트")
+class DiaryQueryAcceptanceTest extends AcceptanceTestBase {
+
+    @Autowired private JwtHandler jwtHandler;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private DiaryRepository diaryRepository;
+    @Autowired private AuditorAware<Long> auditorAware;
+
+    @DisplayName("인증된 멤버가 유효한 조회 시작 일자, 조회 종료 일자를 입력 후 조회를 요청하면 일기 목록 조회에 성공한다.")
+    @Test
+    void when_member_is_authned_and_all_parameters_are_valid_then_query_success() throws JsonProcessingException {
+        //given
+        saveMember(1L);
+        ((AuditorAwareImpl) auditorAware).setCurrentAuditor(1L); // todo 다이어리 CRUD 끝나고 제거..
+        saveDiary("제목", "본문");
+
+        LocalDate nowDate = LocalDate.now().minusDays(1);
+
+        given()
+            .contentType(ContentType.JSON)
+            .header(getAuthHeader(1L))
+            .queryParam("startDate", nowDate.minusDays(1).toString())
+            .queryParam("endDate", nowDate.plusDays(1).toString())
+
+        .when()
+            .get("/api/v1/diaries")
+
+        .then()
+            .statusCode(200)
+            .body("success", equalTo(true))
+            .body("data.id", everyItem(is(1)))
+            .body("data.title", everyItem(is("제목")))
+            .body("data.contents", everyItem(is("본문")))
+            .body("data.createdAt", everyItem(notNullValue(LocalDateTime.class)))
+            .body("data.modifiedAt", everyItem(notNullValue(LocalDateTime.class)))
+            .body("error", nullValue())
+            .log().all();
+    }
+
+    private Header getAuthHeader(Long memberId) {
+        final String token = "Bearer " + jwtHandler.createToken(memberId, Token.ACCESS_TOKEN_EXPIRATION_PERIOD, Instant.now());
+        return new Header(HttpHeaders.AUTHORIZATION, token);
+    }
+
+    private void saveMember(Long memberId) {
+        MemberJpaEntity memberJpaEntity = MemberHelper.createMemberJpaEntity(memberId, "test@email.com", "테스트유저", "test_profile_url",
+            UserRole.NORMAL, Deleted.FALSE);
+        memberRepository.save(memberJpaEntity);
+    }
+
+    private void saveDiary(String title, String contents) {
+        Diary diary = Diary.withoutId(title, contents);
+        DiaryJpaEntity diaryJpaEntity = DiaryJpaEntity.from(diary);
+        diaryRepository.save(diaryJpaEntity);
+    }
+}

--- a/src/test/java/com/woodada/core/diary/adapter/in/DiaryWriteAcceptanceTest.java
+++ b/src/test/java/com/woodada/core/diary/adapter/in/DiaryWriteAcceptanceTest.java
@@ -52,7 +52,7 @@ class DiaryWriteAcceptanceTest extends AcceptanceTestBase {
                 """, DiaryWriteRequest.class))
 
             .when()
-            .post("/api/v1/diary")
+            .post("/api/v1/diaries")
 
             .then()
             .statusCode(200)
@@ -86,7 +86,7 @@ class DiaryWriteAcceptanceTest extends AcceptanceTestBase {
             .body(objectMapper.readValue(titleOver100, DiaryWriteRequest.class))
 
             .when()
-            .post("/api/v1/diary")
+            .post("/api/v1/diaries")
 
             .then()
             .statusCode(400)
@@ -119,7 +119,7 @@ class DiaryWriteAcceptanceTest extends AcceptanceTestBase {
             .body(objectMapper.readValue(titleOver100, DiaryWriteRequest.class))
 
             .when()
-            .post("/api/v1/diary")
+            .post("/api/v1/diaries")
 
             .then()
             .statusCode(400)

--- a/src/test/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapterTest.java
+++ b/src/test/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapterTest.java
@@ -1,10 +1,12 @@
 package com.woodada.core.diary.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woodada.core.diary.domain.Diary;
 import com.woodada.test_helper.IntegrationTestBase;
 import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,5 +45,46 @@ class DiaryPersistenceAdapterTest extends IntegrationTestBase {
 
         //when then
         assertThat(diaryPersistenceAdapter.existsDiary(0L, LocalDate.now())).isTrue();
+    }
+
+    @DisplayName("일기 목록 조회 - 등록자가 null일 경우 NPE 발생")
+    @Test
+    void given_created_by_is_null_when_find_all_then_throws_npe() {
+        assertThatThrownBy(() -> diaryPersistenceAdapter.findAll(null, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1)))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("일기 목록 조회 - 조회 시작 일자가 null일 경우 NPE 발생")
+    @Test
+    void given_start_date_is_null_when_find_all_then_throws_npe() {
+        assertThatThrownBy(() -> diaryPersistenceAdapter.findAll(0L, null, LocalDate.now().plusDays(1)))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("일기 목록 조회 - 조회 종료 일자가 null일 경우 NPE 발생")
+    @Test
+    void given_end_date_is_null_when_find_all_then_throws_npe() {
+        assertThatThrownBy(() -> diaryPersistenceAdapter.findAll(0L, LocalDate.now().minusDays(1), null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("등록자, 조회 시작 일자, 조회 종료 일자가 null이 아니면 일기 목록 조회에 성공한다.")
+    @Test
+    void given_all_args_is_not_null_when_find_all_then_success() {
+        //given
+        Diary diary = Diary.withoutId("제목", "본문");
+        DiaryJpaEntity diaryJpaEntity = DiaryJpaEntity.from(diary);
+        diaryRepository.save(diaryJpaEntity);
+
+        //when
+        //todo 등록자/수정자, 등록일시/수정일시가 audit에 의해 자동으로 입력되기 때문에 통제 불가능
+        // => audit 관련 정보로 조회해야 하는 경우 통제가 안되는데 어떻게 테스트해야 좋을지?
+        List<Diary> diaries = diaryPersistenceAdapter.findAll(0L, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
+
+        //then
+        assertThat(diaries.size()).isEqualTo(1);
+        assertThat(diaries.get(0).getId()).isEqualTo(1L);
+        assertThat(diaries.get(0).getTitle()).isEqualTo("제목");
+        assertThat(diaries.get(0).getContents()).isEqualTo("본문");
     }
 }

--- a/src/test/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapterTest.java
+++ b/src/test/java/com/woodada/core/diary/adapter/out/persistence/DiaryPersistenceAdapterTest.java
@@ -18,9 +18,16 @@ class DiaryPersistenceAdapterTest extends IntegrationTestBase {
     @Autowired private DiaryRepository diaryRepository;
     @Autowired private DiaryPersistenceAdapter diaryPersistenceAdapter;
 
-    @DisplayName("일기 작성 테스트")
+    @DisplayName("[saveDiary] - 일기 도메인 엔티티가 null일 경우 NPE 발생")
     @Test
-    void test_save_diary() {
+    void given_diary_is_null_when_save_diary_then_throws_npe() {
+        assertThatThrownBy(() -> diaryPersistenceAdapter.saveDiary(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("[saveDiary] - 일기 도메인 엔티티가 null이 아닌 경우 일기 저장에 성공한다")
+    @Test
+    void given_all_args_are_not_null_when_save_diary_then_success() {
         //given
         Diary newDiary = Diary.withoutId("제목", "본문");
 
@@ -31,6 +38,37 @@ class DiaryPersistenceAdapterTest extends IntegrationTestBase {
         assertThat(savedDiary.getId()).isEqualTo(1L);
         assertThat(savedDiary.getTitle()).isEqualTo("제목");
         assertThat(savedDiary.getContents()).isEqualTo("본문");
+    }
+
+    @DisplayName("[findDiary] - id가 null일 경우 NPE 발생")
+    @Test
+    void given_id_is_null_when_find_diary_then_throws_npe() {
+        assertThatThrownBy(() -> diaryPersistenceAdapter.findDiary(null, 1L))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("[findDiary] - createdBy가 null일 경우 NPE 발생")
+    @Test
+    void given_created_by_is_null_when_find_diary_then_throws_npe() {
+        assertThatThrownBy(() -> diaryPersistenceAdapter.findDiary(1L, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("[findDiary] - 모든 인자가 null이 아닌 경우 일기 조회에 성공한다")
+    @Test
+    void given_all_args_are_not_null_when_find_diary_then_success() {
+        //given
+        Diary diary = Diary.withoutId("제목", "본문");
+        DiaryJpaEntity diaryJpaEntity = DiaryJpaEntity.from(diary);
+        diaryRepository.save(diaryJpaEntity);
+
+        //when
+        //todo 영속성 어댑터 테스트할 때 등록자/수정자 어떻게 처리하면 좋을까..
+        Diary foundDiary = diaryPersistenceAdapter.findDiary(1L, 0L).get();
+
+        //then
+        assertThat(foundDiary.getTitle()).isEqualTo("제목");
+        assertThat(foundDiary.getContents()).isEqualTo("본문");
     }
 
     @Disabled("usecase 테스트에서 writeDate를 더 의미있게 테스트할 수 있다. 00:00를 걸쳐서 저장, 조회가 수행되면 테스트가 실패할 수 있음. + 스프링 시큐리티 적용 후 createdBy 재확인")
@@ -47,30 +85,30 @@ class DiaryPersistenceAdapterTest extends IntegrationTestBase {
         assertThat(diaryPersistenceAdapter.existsDiary(0L, LocalDate.now())).isTrue();
     }
 
-    @DisplayName("일기 목록 조회 - 등록자가 null일 경우 NPE 발생")
+    @DisplayName("[findAll] - 등록자가 null일 경우 NPE 발생")
     @Test
     void given_created_by_is_null_when_find_all_then_throws_npe() {
         assertThatThrownBy(() -> diaryPersistenceAdapter.findAll(null, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1)))
             .isInstanceOf(NullPointerException.class);
     }
 
-    @DisplayName("일기 목록 조회 - 조회 시작 일자가 null일 경우 NPE 발생")
+    @DisplayName("[findAll] - 조회 시작 일자가 null일 경우 NPE 발생")
     @Test
     void given_start_date_is_null_when_find_all_then_throws_npe() {
         assertThatThrownBy(() -> diaryPersistenceAdapter.findAll(0L, null, LocalDate.now().plusDays(1)))
             .isInstanceOf(NullPointerException.class);
     }
 
-    @DisplayName("일기 목록 조회 - 조회 종료 일자가 null일 경우 NPE 발생")
+    @DisplayName("[findAll] - 조회 종료 일자가 null일 경우 NPE 발생")
     @Test
     void given_end_date_is_null_when_find_all_then_throws_npe() {
         assertThatThrownBy(() -> diaryPersistenceAdapter.findAll(0L, LocalDate.now().minusDays(1), null))
             .isInstanceOf(NullPointerException.class);
     }
 
-    @DisplayName("등록자, 조회 시작 일자, 조회 종료 일자가 null이 아니면 일기 목록 조회에 성공한다.")
+    @DisplayName("[findAll] - 모든 인자가 null이 아닌 경우 일기 목록 조회에 성공한다.")
     @Test
-    void given_all_args_is_not_null_when_find_all_then_success() {
+    void given_all_args_are_not_null_when_find_all_then_success() {
         //given
         Diary diary = Diary.withoutId("제목", "본문");
         DiaryJpaEntity diaryJpaEntity = DiaryJpaEntity.from(diary);

--- a/src/test/java/com/woodada/core/diary/application/port/in/DiaryQueryCommandTest.java
+++ b/src/test/java/com/woodada/core/diary/application/port/in/DiaryQueryCommandTest.java
@@ -1,0 +1,35 @@
+package com.woodada.core.diary.application.port.in;
+
+import java.time.LocalDate;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[unit test] DiaryQueryCommand 단위 테스트")
+public class DiaryQueryCommandTest {
+
+    @DisplayName("일기 조회 객체의 조회 시작 일자에 null을 입력하면 예외가 발생한다.")
+    @Test
+    void given_null_start_date_then_throw_exception() {
+        Assertions.assertThatThrownBy(() -> new DiaryQueryCommand(null, LocalDate.now()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("조회 시작 일자를 입력해 주세요.");
+    }
+
+    @DisplayName("일기 조회 객체의 조회 종료 일자에 null을 입력하면 예외가 발생한다.")
+    @Test
+    void given_null_end_date_then_throw_exception() {
+        Assertions.assertThatThrownBy(() -> new DiaryQueryCommand(LocalDate.now(), null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("조회 종료 일자를 입력해 주세요.");
+    }
+
+    @DisplayName("일기 조회 객체의 조회 시작 일자가 조회 종료 일자보다 미래 일자이면 예외가 발생한다.")
+    @Test
+    void given_start_date_is_after_than_end_date_then_throw_exception() {
+        LocalDate endDate = LocalDate.now();
+        Assertions.assertThatThrownBy(() -> new DiaryQueryCommand(endDate.plusDays(1), endDate))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("조회 일자 범위가 유효하지 않습니다.");
+    }
+}

--- a/src/test/java/com/woodada/core/diary/application/service/DiaryQueryServiceTest.java
+++ b/src/test/java/com/woodada/core/diary/application/service/DiaryQueryServiceTest.java
@@ -1,0 +1,75 @@
+package com.woodada.core.diary.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.woodada.common.auth.argument_resolver.MemberHelper;
+import com.woodada.common.auth.argument_resolver.WddMember;
+import com.woodada.common.auth.domain.UserRole;
+import com.woodada.core.diary.application.port.in.DiaryQueryCommand;
+import com.woodada.core.diary.application.port.out.DiaryFindPort;
+import com.woodada.core.diary.domain.Diary;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[unit test] DiaryQueryService 단위테스트")
+public class DiaryQueryServiceTest {
+
+    @Mock
+    private DiaryFindPort findDiaryPort;
+
+    private DiaryQueryService diaryQueryService;
+
+    @BeforeEach
+    void setUp() {
+        diaryQueryService = new DiaryQueryService(findDiaryPort);
+    }
+
+    @DisplayName("wddMember 인자가 null이면 예외가 발생한다.")
+    @Test
+    void given_wddMember_is_null_then_throw_exception() {
+        DiaryQueryCommand command = new DiaryQueryCommand(LocalDate.now(), LocalDate.now().plusDays(30));
+
+        assertThatThrownBy(() -> diaryQueryService.queryDiaries(null, command))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("command 인자가 null이면 예외가 발생한다.")
+    @Test
+    void given_command_is_null_then_throw_exception() {
+        WddMember wddMember = getWddMember(1L);
+
+        assertThatThrownBy(() -> diaryQueryService.queryDiaries(wddMember, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("유효한 일기 조회 객체를 전달받으면 조회에 성공한다.")
+    @Test
+    void given_valid_command_then_diary_is_wrote() {
+        //given
+        WddMember wddMember = getWddMember(1L);
+        DiaryQueryCommand command = new DiaryQueryCommand(LocalDate.now(), LocalDate.now().plusDays(30));
+        given(findDiaryPort.findAll(wddMember.getId(), command.startDate(), command.endDate()))
+            .willReturn(List.of(Diary.withId(1L, "제목", "본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now())));
+
+        //when
+        List<Diary> diaries = diaryQueryService.queryDiaries(wddMember, command);
+
+        //then
+        assertThat(diaries.size()).isEqualTo(1);
+        assertThat(diaries.get(0).getId()).isEqualTo(1L);
+    }
+    private WddMember getWddMember(Long memberId) {
+        WddMember writer = MemberHelper.createWddMember(memberId, "test@email.com", "테스트유저", "test_protile_url", UserRole.NORMAL);
+        return writer;
+    }
+}

--- a/src/test/java/com/woodada/core/diary/application/service/DiaryQueryServiceTest.java
+++ b/src/test/java/com/woodada/core/diary/application/service/DiaryQueryServiceTest.java
@@ -13,6 +13,7 @@ import com.woodada.core.diary.domain.Diary;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ public class DiaryQueryServiceTest {
         diaryQueryService = new DiaryQueryService(findDiaryPort);
     }
 
-    @DisplayName("[queryDiaries] - wddMember 인자가 null이면 예외가 발생한다.")
+    @DisplayName("[queryDiaries] - wddMember가 null인 경우 예외가 발생한다.")
     @Test
     void given_wdd_member_is_null_when_query_diaries_then_throw_exception() {
         DiaryQueryCommand command = new DiaryQueryCommand(LocalDate.now(), LocalDate.now().plusDays(30));
@@ -68,6 +69,41 @@ public class DiaryQueryServiceTest {
         assertThat(diaries.size()).isEqualTo(1);
         assertThat(diaries.get(0).getId()).isEqualTo(1L);
     }
+
+    @DisplayName("[queryDiary] - wddMember가 null일 경우 예외가 발생한다.")
+    @Test
+    void given_wdd_member_is_null_when_query_diary_then_throw_exception() {
+        assertThatThrownBy(() -> diaryQueryService.queryDiary(null, 1L))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("[queryDiary] - id가 null일 경우 예외가 발생한다.")
+    @Test
+    void given_id_is_null_when_query_diary__then_throw_exception() {
+        WddMember wddMember = getWddMember(1L);
+
+        assertThatThrownBy(() -> diaryQueryService.queryDiary(wddMember, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("[queryDiary] - 모든 인자가 유효한 경우 일기 조회에 성공한다.")
+    @Test
+    void given_all_args_are_not_null_when_query_diary_then_query_success() {
+        //given
+        WddMember wddMember = getWddMember(1L);
+        given(findDiaryPort.findDiary(1L, 1L))
+            .willReturn(Optional.of(Diary.withId(1L, "제목", "본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now())));
+
+        //when
+        Diary diary = diaryQueryService.queryDiary(wddMember, 1L);
+
+        //then
+        assertThat(diary.getId()).isEqualTo(1L);
+        assertThat(diary.getTitle()).isEqualTo("제목");
+        assertThat(diary.getContents()).isEqualTo("본문");
+        assertThat(diary.getCreatedBy()).isEqualTo(1L);
+    }
+
 
     private WddMember getWddMember(Long memberId) {
         WddMember writer = MemberHelper.createWddMember(memberId, "test@email.com", "테스트유저", "test_protile_url", UserRole.NORMAL);

--- a/src/test/java/com/woodada/core/diary/application/service/DiaryQueryServiceTest.java
+++ b/src/test/java/com/woodada/core/diary/application/service/DiaryQueryServiceTest.java
@@ -34,27 +34,27 @@ public class DiaryQueryServiceTest {
         diaryQueryService = new DiaryQueryService(findDiaryPort);
     }
 
-    @DisplayName("wddMember 인자가 null이면 예외가 발생한다.")
+    @DisplayName("[queryDiaries] - wddMember 인자가 null이면 예외가 발생한다.")
     @Test
-    void given_wddMember_is_null_then_throw_exception() {
+    void given_wdd_member_is_null_when_query_diaries_then_throw_exception() {
         DiaryQueryCommand command = new DiaryQueryCommand(LocalDate.now(), LocalDate.now().plusDays(30));
 
         assertThatThrownBy(() -> diaryQueryService.queryDiaries(null, command))
             .isInstanceOf(NullPointerException.class);
     }
 
-    @DisplayName("command 인자가 null이면 예외가 발생한다.")
+    @DisplayName("[queryDiaries] - command가 null인 경우 예외가 발생한다.")
     @Test
-    void given_command_is_null_then_throw_exception() {
+    void given_command_is_null_when_query_diaries__then_throw_exception() {
         WddMember wddMember = getWddMember(1L);
 
         assertThatThrownBy(() -> diaryQueryService.queryDiaries(wddMember, null))
             .isInstanceOf(NullPointerException.class);
     }
 
-    @DisplayName("유효한 일기 조회 객체를 전달받으면 조회에 성공한다.")
+    @DisplayName("[queryDiaries] - 모든 인자가 유효한 경우 일기 목록 조회에 성공한다.")
     @Test
-    void given_valid_command_then_diary_is_wrote() {
+    void given_all_args_are_not_null_when_query_diaries_then_query_success() {
         //given
         WddMember wddMember = getWddMember(1L);
         DiaryQueryCommand command = new DiaryQueryCommand(LocalDate.now(), LocalDate.now().plusDays(30));
@@ -68,6 +68,7 @@ public class DiaryQueryServiceTest {
         assertThat(diaries.size()).isEqualTo(1);
         assertThat(diaries.get(0).getId()).isEqualTo(1L);
     }
+
     private WddMember getWddMember(Long memberId) {
         WddMember writer = MemberHelper.createWddMember(memberId, "test@email.com", "테스트유저", "test_protile_url", UserRole.NORMAL);
         return writer;

--- a/src/test/java/com/woodada/core/diary/application/service/DiaryWriteServiceTest.java
+++ b/src/test/java/com/woodada/core/diary/application/service/DiaryWriteServiceTest.java
@@ -16,6 +16,7 @@ import com.woodada.core.diary.application.port.out.DiaryFindPort;
 import com.woodada.core.diary.application.port.out.DiarySavePort;
 import com.woodada.core.diary.domain.Diary;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,7 @@ class DiaryWriteServiceTest {
         WddMember wddMember = getWddMember(1L);
         DiaryWriteCommand writeDiaryCommand = new DiaryWriteCommand("100자 이하의 제목", "5000자 이하의 본문", LocalDate.now());
         given(saveDiaryPort.saveDiary(any(Diary.class)))
-            .willReturn(Diary.withId(1L, "100자 이하의 제목", "5000자 이하의 본문"));
+            .willReturn(Diary.withId(1L, "100자 이하의 제목", "5000자 이하의 본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now()));
 
         //when
         Diary savedDiary = writeDiaryService.writeDiary(wddMember, writeDiaryCommand);

--- a/src/test/java/com/woodada/core/diary/domain/DiaryTest.java
+++ b/src/test/java/com/woodada/core/diary/domain/DiaryTest.java
@@ -1,5 +1,6 @@
 package com.woodada.core.diary.domain;
 
+import java.time.LocalDateTime;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,7 @@ public class DiaryTest {
     @ParameterizedTest
     @NullAndEmptySource
     void given_title_length_less_than_1_when_modify_then_throw_exception(String title) {
-        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문");
+        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
 
         Assertions.assertThatThrownBy(() -> diary.modify(title, "수정 후 본문"))
             .isInstanceOf(IllegalArgumentException.class)
@@ -24,7 +25,7 @@ public class DiaryTest {
     @ParameterizedTest
     @NullAndEmptySource
     void given_contents_length_less_than_1_when_modify_then_throw_exception(String contents) {
-        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문");
+        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
 
         Assertions.assertThatThrownBy(() -> diary.modify("수정 후 제목", contents))
             .isInstanceOf(IllegalArgumentException.class)
@@ -34,7 +35,7 @@ public class DiaryTest {
     @DisplayName("한 글자 이상의 제목과 본문을 전달하면 일기를 수정할 수 있다.")
     @Test
     void given_title_and_contents_greater_than_or_equal_to_1_when_modify_then_success() {
-        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문");
+        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
 
         diary.modify("제목", "본문");
 

--- a/src/test/java/com/woodada/test_helper/AcceptanceTestBase.java
+++ b/src/test/java/com/woodada/test_helper/AcceptanceTestBase.java
@@ -1,12 +1,14 @@
 package com.woodada.test_helper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woodada.common.config.jpa.AuditorAwareImpl;
 import com.woodada.test_helper.annotation.IntegrationTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.domain.AuditorAware;
 
 @IntegrationTest
 public abstract class AcceptanceTestBase {
@@ -15,6 +17,7 @@ public abstract class AcceptanceTestBase {
 
     @Autowired private RDBInitialization rdbInitialization;
     @Autowired private RedisInitialization redisInitialization;
+    @Autowired private AuditorAware<Long> auditorAware;
 
     protected final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -28,5 +31,6 @@ public abstract class AcceptanceTestBase {
     void cleanUp() {
         rdbInitialization.truncateAllEntity();
         redisInitialization.initRedis();
+        ((AuditorAwareImpl) auditorAware).setCurrentAuditor(0L); // todo 다이어리 CRUD 끝나고 변경..
     }
 }


### PR DESCRIPTION
## 📍 이슈 번호
#36 

## 📚 작업 내용
- 일기 조회 api 구현 및 테스트 코드 추가
- AcceptanceTestBase cleanUp 메서드에서 audit 정보 초기화 코드 추가(개선 필요)
