### PR TITLE
[30-35] 일기 삭제 api 구현

### DIFF
--- a/src/main/java/com/woodada/common/support/CreatorBaseEntity.java
+++ b/src/main/java/com/woodada/common/support/CreatorBaseEntity.java
@@ -21,4 +21,12 @@ public abstract class CreatorBaseEntity {
     @CreatedDate
     @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
+
+    public CreatorBaseEntity() {
+    }
+
+    public CreatorBaseEntity(final Long createdBy, final LocalDateTime createdAt) {
+        this.createdBy = createdBy;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/woodada/common/support/ModifierBaseEntity.java
+++ b/src/main/java/com/woodada/common/support/ModifierBaseEntity.java
@@ -21,4 +21,13 @@ public abstract class ModifierBaseEntity extends CreatorBaseEntity {
     @LastModifiedDate
     @Column(name = "modified_at")
     private LocalDateTime modifiedAt;
+
+    public ModifierBaseEntity() {
+    }
+
+    public ModifierBaseEntity(final Long createdBy, final LocalDateTime createdAt, final Long modifiedBy, final LocalDateTime modifiedAt) {
+        super(createdBy, createdAt);
+        this.modifiedBy = modifiedBy;
+        this.modifiedAt = modifiedAt;
+    }
 }

--- a/src/main/java/com/woodada/core/diary/adapter/in/DiaryDeleteAdapter.java
+++ b/src/main/java/com/woodada/core/diary/adapter/in/DiaryDeleteAdapter.java
@@ -1,0 +1,28 @@
+package com.woodada.core.diary.adapter.in;
+
+import com.woodada.common.auth.argument_resolver.WddMember;
+import com.woodada.common.support.ApiResponse;
+import com.woodada.core.diary.application.port.in.DiaryDeleteUseCase;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/diaries")
+public class DiaryDeleteAdapter {
+
+    private final DiaryDeleteUseCase diaryDeleteUseCase;
+
+    public DiaryDeleteAdapter(final DiaryDeleteUseCase diaryDeleteUseCase) {
+        this.diaryDeleteUseCase = diaryDeleteUseCase;
+    }
+
+    @DeleteMapping("/{id}")
+    ResponseEntity<ApiResponse<Void>> deleteDiary(WddMember wddMember,  @PathVariable Long id) {
+        diaryDeleteUseCase.deleteDiary(wddMember, id);
+
+        return ResponseEntity.ok(ApiResponse.OK);
+    }
+}

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryJpaEntity.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryJpaEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,7 +35,17 @@ public class DiaryJpaEntity extends ModifierBaseEntity {
     @Column(name = "deleted", nullable = false, length = 5)
     private Deleted deleted;
 
-    private DiaryJpaEntity(final Long id, final String title, final String contents, final Deleted deleted) {
+    private DiaryJpaEntity(
+        final Long id,
+        final String title,
+        final String contents,
+        final Deleted deleted,
+        final Long createdBy,
+        final LocalDateTime createdAt,
+        final Long modifiedBy,
+        final LocalDateTime modifiedAt
+    ) {
+        super(createdBy, createdAt, modifiedBy, modifiedAt);
         this.id = id;
         this.title = title;
         this.contents = contents;
@@ -51,7 +62,8 @@ public class DiaryJpaEntity extends ModifierBaseEntity {
     public static DiaryJpaEntity from(final Diary diary) {
         Objects.requireNonNull(diary);
 
-        return new DiaryJpaEntity(diary.getId(), diary.getTitle(), diary.getContents(), Deleted.FALSE);
+        return new DiaryJpaEntity(diary.getId(), diary.getTitle(), diary.getContents(), diary.getDeleted(),
+            diary.getCreatedBy(), diary.getCreatedAt(), diary.getModifiedBy(), diary.getModifiedAt());
     }
 
     /**
@@ -60,6 +72,6 @@ public class DiaryJpaEntity extends ModifierBaseEntity {
      * @return 일기 도메인 엔티티
      */
     public Diary toDomainEntity() {
-        return Diary.withId(id, title, contents, Deleted.FALSE, getCreatedBy(), getCreatedAt(), getModifiedBy(), getModifiedAt());
+        return Diary.withId(id, title, contents, deleted, getCreatedBy(), getCreatedAt(), getModifiedBy(), getModifiedAt());
     }
 }

--- a/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryJpaEntity.java
+++ b/src/main/java/com/woodada/core/diary/adapter/out/persistence/DiaryJpaEntity.java
@@ -2,8 +2,11 @@ package com.woodada.core.diary.adapter.out.persistence;
 
 import com.woodada.common.support.ModifierBaseEntity;
 import com.woodada.core.diary.domain.Diary;
+import com.woodada.support.Deleted;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,10 +30,15 @@ public class DiaryJpaEntity extends ModifierBaseEntity {
     @Column(name = "contents", nullable = false, length = 5000)
     private String contents;
 
-    private DiaryJpaEntity(final Long id, final String title, final String contents) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "deleted", nullable = false, length = 5)
+    private Deleted deleted;
+
+    private DiaryJpaEntity(final Long id, final String title, final String contents, final Deleted deleted) {
         this.id = id;
         this.title = title;
         this.contents = contents;
+        this.deleted = deleted;
     }
 
     /**
@@ -43,7 +51,7 @@ public class DiaryJpaEntity extends ModifierBaseEntity {
     public static DiaryJpaEntity from(final Diary diary) {
         Objects.requireNonNull(diary);
 
-        return new DiaryJpaEntity(diary.getId(), diary.getTitle(), diary.getContents());
+        return new DiaryJpaEntity(diary.getId(), diary.getTitle(), diary.getContents(), Deleted.FALSE);
     }
 
     /**
@@ -52,6 +60,6 @@ public class DiaryJpaEntity extends ModifierBaseEntity {
      * @return 일기 도메인 엔티티
      */
     public Diary toDomainEntity() {
-        return Diary.withId(id, title, contents, getCreatedBy(), getCreatedAt(), getModifiedBy(), getModifiedAt());
+        return Diary.withId(id, title, contents, Deleted.FALSE, getCreatedBy(), getCreatedAt(), getModifiedBy(), getModifiedAt());
     }
 }

--- a/src/main/java/com/woodada/core/diary/application/port/in/DiaryDeleteUseCase.java
+++ b/src/main/java/com/woodada/core/diary/application/port/in/DiaryDeleteUseCase.java
@@ -1,0 +1,17 @@
+package com.woodada.core.diary.application.port.in;
+
+import com.woodada.common.auth.argument_resolver.WddMember;
+
+public interface DiaryDeleteUseCase {
+
+    /**
+     * 일기를 삭제한다
+     *
+     * @param wddMember 인증된 멤버 정보
+     * @param id        일기 id
+     * @throws NullPointerException wddMember, id 중 하나라도 null이 입력된 경우
+     * @throws com.woodada.common.exception.WddException 일기가 조회되지 않은 경우
+     *
+     */
+    void deleteDiary(WddMember wddMember, Long id);
+}

--- a/src/main/java/com/woodada/core/diary/application/port/in/DiaryModifyUseCase.java
+++ b/src/main/java/com/woodada/core/diary/application/port/in/DiaryModifyUseCase.java
@@ -9,6 +9,7 @@ public interface DiaryModifyUseCase {
      *
      * @param wddMember 인증된 멤버 정보
      * @param command   일기 수정 정보
+     * @throws NullPointerException                      wddMember, command 중 하나라도 null이 입력된 경우
      * @throws com.woodada.common.exception.WddException 일기가 조회되지 않은 경우
      * @throws IllegalArgumentException                  입력 값이 유효 범위를 위반한 경우
      */

--- a/src/main/java/com/woodada/core/diary/application/port/out/DiarySavePort.java
+++ b/src/main/java/com/woodada/core/diary/application/port/out/DiarySavePort.java
@@ -5,11 +5,11 @@ import com.woodada.core.diary.domain.Diary;
 public interface DiarySavePort {
 
     /**
-     * 일기를 신규 저장한다.
+     * 일기를 저장한다.
      *
-     * @param diary 신규 저장 될 일기
+     * @param diary 저장 될 일기
      * @throws NullPointerException diary에 null이 입력된 경우
-     * @return id가 부여된 일기
+     * @return 저장된 일기
      */
     Diary saveDiary(Diary diary);
 }

--- a/src/main/java/com/woodada/core/diary/application/service/DiaryDeleteService.java
+++ b/src/main/java/com/woodada/core/diary/application/service/DiaryDeleteService.java
@@ -1,0 +1,34 @@
+package com.woodada.core.diary.application.service;
+
+import com.woodada.common.auth.argument_resolver.WddMember;
+import com.woodada.common.exception.WddException;
+import com.woodada.core.diary.application.port.in.DiaryDeleteUseCase;
+import com.woodada.core.diary.application.port.out.DiaryFindPort;
+import com.woodada.core.diary.application.port.out.DiarySavePort;
+import com.woodada.core.diary.domain.Diary;
+import com.woodada.core.diary.domain.DiaryException;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DiaryDeleteService implements DiaryDeleteUseCase {
+
+    private final DiaryFindPort diaryFindPort;
+    private final DiarySavePort diarySavePort;
+
+    public DiaryDeleteService(final DiaryFindPort diaryFindPort, final DiarySavePort diarySavePort) {
+        this.diaryFindPort = diaryFindPort;
+        this.diarySavePort = diarySavePort;
+    }
+
+    @Override
+    public void deleteDiary(final WddMember wddMember, final Long id) {
+        Objects.requireNonNull(wddMember);
+        Objects.requireNonNull(id);
+
+        final Diary diary = diaryFindPort.findDiary(id, wddMember.getId())
+            .orElseThrow(() -> new WddException(DiaryException.NONE_CONTENTS));
+        diary.delete();
+        diarySavePort.saveDiary(diary);
+    }
+}

--- a/src/main/java/com/woodada/core/diary/domain/Diary.java
+++ b/src/main/java/com/woodada/core/diary/domain/Diary.java
@@ -1,5 +1,6 @@
 package com.woodada.core.diary.domain;
 
+import com.woodada.support.Deleted;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.util.ObjectUtils;
@@ -10,6 +11,7 @@ public class Diary {
     private final Long id;
     private String title;
     private String contents;
+    private Deleted deleted;
     private Long createdBy;
     private LocalDateTime createdAt;
     private Long modifiedBy;
@@ -19,6 +21,7 @@ public class Diary {
         final Long id,
         final String title,
         final String contents,
+        final Deleted deleted,
         final Long createdBy,
         final LocalDateTime createdAt,
         final Long modifiedBy,
@@ -27,6 +30,7 @@ public class Diary {
         this.id = id;
         this.title = title;
         this.contents = contents;
+        this.deleted = deleted;
         this.createdBy = createdBy;
         this.createdAt = createdAt;
         this.modifiedBy = modifiedBy;
@@ -50,7 +54,7 @@ public class Diary {
             throw new IllegalArgumentException("일기 본문을 한 글자 이상 입력해 주세요.");
         }
 
-        return new Diary(null, title, contents, null, null, null, null);
+        return new Diary(null, title, contents,  Deleted.FALSE, null, null, null, null);
     }
 
     /**
@@ -59,6 +63,7 @@ public class Diary {
      * @param id       diary id
      * @param title    제목
      * @param contents 본문
+     * @param deleted 삭제 여부
      * @param createdBy 등록자
      * @param createdAt 등록 일시
      * @param modifiedBy 최종 수정자
@@ -69,12 +74,13 @@ public class Diary {
         final Long id,
         final String title,
         final String contents,
+        final Deleted deleted,
         final Long createdBy,
         final LocalDateTime createdAt,
         final Long modifiedBy,
         final LocalDateTime modifiedAt
     ) {
-        return new Diary(id, title, contents, createdBy, createdAt, modifiedBy, modifiedAt);
+        return new Diary(id, title, contents, deleted, createdBy, createdAt, modifiedBy, modifiedAt);
     }
 
     /**
@@ -95,5 +101,9 @@ public class Diary {
 
         this.title = title;
         this.contents = contents;
+    }
+
+    public void delete() {
+        this.deleted = Deleted.TRUE;
     }
 }

--- a/src/main/java/com/woodada/support/Deleted.java
+++ b/src/main/java/com/woodada/support/Deleted.java
@@ -1,0 +1,7 @@
+package com.woodada.support;
+
+public enum Deleted {
+
+    TRUE,
+    FALSE
+}

--- a/src/test/java/com/woodada/core/diary/adapter/in/DiaryDeleteAcceptanceTest.java
+++ b/src/test/java/com/woodada/core/diary/adapter/in/DiaryDeleteAcceptanceTest.java
@@ -1,0 +1,82 @@
+package com.woodada.core.diary.adapter.in;
+
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.woodada.common.auth.adapter.out.persistence.MemberJpaEntity;
+import com.woodada.common.auth.adapter.out.persistence.MemberRepository;
+import com.woodada.common.auth.argument_resolver.MemberHelper;
+import com.woodada.common.auth.domain.Deleted;
+import com.woodada.common.auth.domain.JwtHandler;
+import com.woodada.common.auth.domain.Token;
+import com.woodada.common.auth.domain.UserRole;
+import com.woodada.common.config.jpa.AuditorAwareImpl;
+import com.woodada.core.diary.adapter.out.persistence.DiaryJpaEntity;
+import com.woodada.core.diary.adapter.out.persistence.DiaryRepository;
+import com.woodada.core.diary.domain.Diary;
+import com.woodada.test_helper.AcceptanceTestBase;
+import io.restassured.http.Header;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.http.HttpHeaders;
+
+@DisplayName("[acceptance test] 다이어리 삭제 인수 테스트")
+class DiaryDeleteAcceptanceTest extends AcceptanceTestBase {
+
+    @Autowired private JwtHandler jwtHandler;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private DiaryRepository diaryRepository;
+    @Autowired private AuditorAware<Long> auditorAware;
+
+    @DisplayName("인증된 멤버가 유효한 id를 입력 후 삭제를 요청하면 삭제에 성공한다.")
+    @Test
+    void when_member_is_authned_and_id_is_valid_then_delete_diary_success() {
+        saveMember(1L);
+        ((AuditorAwareImpl) auditorAware).setCurrentAuditor(1L); // todo 다이어리 CRUD 끝나고 제거..
+        saveDiary("제목", "본문");
+
+        given()
+            .header(getAuthHeader(1L))
+            .pathParam("id", 1L)
+
+        .when()
+            .delete("/api/v1/diaries/{id}")
+
+        .then()
+            .statusCode(200)
+            .body("success", equalTo(true))
+            .body("data", nullValue())
+            .body("error", nullValue())
+            .log().all();
+
+        List<DiaryJpaEntity> diaries = diaryRepository.findAll();
+
+        assertThat(diaries.size()).isEqualTo(1);
+        assertThat(diaries.get(0).getId()).isEqualTo(1L);
+        assertThat(diaries.get(0).getDeleted()).isEqualTo(com.woodada.support.Deleted.TRUE);
+    }
+
+    private Header getAuthHeader(Long memberId) {
+        final String token = "Bearer " + jwtHandler.createToken(memberId, Token.ACCESS_TOKEN_EXPIRATION_PERIOD, Instant.now());
+        return new Header(HttpHeaders.AUTHORIZATION, token);
+    }
+
+    private void saveMember(Long memberId) {
+        MemberJpaEntity memberJpaEntity = MemberHelper.createMemberJpaEntity(memberId, "test@email.com", "테스트유저", "test_profile_url",
+            UserRole.NORMAL, Deleted.FALSE);
+        memberRepository.save(memberJpaEntity);
+    }
+
+    private void saveDiary(String title, String contents) {
+        Diary diary = Diary.withoutId(title, contents);
+        DiaryJpaEntity diaryJpaEntity = DiaryJpaEntity.from(diary);
+        diaryRepository.save(diaryJpaEntity);
+    }
+}

--- a/src/test/java/com/woodada/core/diary/application/service/DiaryDeleteServiceTest.java
+++ b/src/test/java/com/woodada/core/diary/application/service/DiaryDeleteServiceTest.java
@@ -1,0 +1,77 @@
+package com.woodada.core.diary.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.woodada.common.auth.argument_resolver.MemberHelper;
+import com.woodada.common.auth.argument_resolver.WddMember;
+import com.woodada.common.auth.domain.UserRole;
+import com.woodada.core.diary.application.port.out.DiaryFindPort;
+import com.woodada.core.diary.application.port.out.DiarySavePort;
+import com.woodada.core.diary.domain.Diary;
+import com.woodada.support.Deleted;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[unit test] DiaryDeleteService 단위테스트")
+class DiaryDeleteServiceTest {
+
+    @Mock private DiaryFindPort diaryFindPort;
+    @Mock private DiarySavePort diarySavePort;
+
+    private DiaryDeleteService diaryDeleteService;
+
+    @BeforeEach
+    void setUp() {
+        diaryDeleteService = new DiaryDeleteService(diaryFindPort, diarySavePort);
+    }
+
+    @DisplayName("[deleteDiary] - wddMember가 null인 경우 예외가 발생한다.")
+    @Test
+    void given_wdd_member_is_null_when_delete_diary_then_throw_exception() {
+        assertThatThrownBy(() -> diaryDeleteService.deleteDiary(null, 1L))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("[deleteDiary] - id가 null인 경우 예외가 발생한다.")
+    @Test
+    void given_id_is_null_when_delete_diary_then_throw_exception() {
+        WddMember wddMember = getWddMember(1L);
+
+        assertThatThrownBy(() -> diaryDeleteService.deleteDiary(wddMember, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("[deleteDiary] - 모든 인자가 유효한 경우 일기 삭제에 성공한다.")
+    @Test
+    void given_all_args_are_valid_when_delete_diary_then_delete_success() {
+        //given
+        WddMember wddMember = getWddMember(1L);
+        Diary foundDiary = Diary.withId(1L, "제목", "본문", Deleted.FALSE, 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
+        given(diaryFindPort.findDiary(1L, 1L))
+            .willReturn(Optional.of(foundDiary));
+
+        //when
+        diaryDeleteService.deleteDiary(wddMember, 1L);
+
+        //then
+        assertThat(foundDiary.getDeleted()).isEqualTo(Deleted.TRUE);
+        then(diarySavePort).should(times(1)).saveDiary(any(Diary.class));
+    }
+
+    private WddMember getWddMember(Long memberId) {
+        WddMember writer = MemberHelper.createWddMember(memberId, "test@email.com", "테스트유저", "test_protile_url", UserRole.NORMAL);
+        return writer;
+    }
+}

--- a/src/test/java/com/woodada/core/diary/application/service/DiaryQueryServiceTest.java
+++ b/src/test/java/com/woodada/core/diary/application/service/DiaryQueryServiceTest.java
@@ -10,6 +10,7 @@ import com.woodada.common.auth.domain.UserRole;
 import com.woodada.core.diary.application.port.in.DiaryQueryCommand;
 import com.woodada.core.diary.application.port.out.DiaryFindPort;
 import com.woodada.core.diary.domain.Diary;
+import com.woodada.support.Deleted;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -60,7 +61,7 @@ public class DiaryQueryServiceTest {
         WddMember wddMember = getWddMember(1L);
         DiaryQueryCommand command = new DiaryQueryCommand(LocalDate.now(), LocalDate.now().plusDays(30));
         given(findDiaryPort.findAll(wddMember.getId(), command.startDate(), command.endDate()))
-            .willReturn(List.of(Diary.withId(1L, "제목", "본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now())));
+            .willReturn(List.of(Diary.withId(1L, "제목", "본문", Deleted.FALSE, 1L, LocalDateTime.now(), 1L, LocalDateTime.now())));
 
         //when
         List<Diary> diaries = diaryQueryService.queryDiaries(wddMember, command);
@@ -92,7 +93,7 @@ public class DiaryQueryServiceTest {
         //given
         WddMember wddMember = getWddMember(1L);
         given(findDiaryPort.findDiary(1L, 1L))
-            .willReturn(Optional.of(Diary.withId(1L, "제목", "본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now())));
+            .willReturn(Optional.of(Diary.withId(1L, "제목", "본문", Deleted.FALSE, 1L, LocalDateTime.now(), 1L, LocalDateTime.now())));
 
         //when
         Diary diary = diaryQueryService.queryDiary(wddMember, 1L);

--- a/src/test/java/com/woodada/core/diary/application/service/DiaryWriteServiceTest.java
+++ b/src/test/java/com/woodada/core/diary/application/service/DiaryWriteServiceTest.java
@@ -15,6 +15,7 @@ import com.woodada.core.diary.application.port.in.DiaryWriteCommand;
 import com.woodada.core.diary.application.port.out.DiaryFindPort;
 import com.woodada.core.diary.application.port.out.DiarySavePort;
 import com.woodada.core.diary.domain.Diary;
+import com.woodada.support.Deleted;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,7 +46,7 @@ class DiaryWriteServiceTest {
         WddMember wddMember = getWddMember(1L);
         DiaryWriteCommand writeDiaryCommand = new DiaryWriteCommand("100자 이하의 제목", "5000자 이하의 본문", LocalDate.now());
         given(saveDiaryPort.saveDiary(any(Diary.class)))
-            .willReturn(Diary.withId(1L, "100자 이하의 제목", "5000자 이하의 본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now()));
+            .willReturn(Diary.withId(1L, "100자 이하의 제목", "5000자 이하의 본문", Deleted.FALSE, 1L, LocalDateTime.now(), 1L, LocalDateTime.now()));
 
         //when
         Diary savedDiary = writeDiaryService.writeDiary(wddMember, writeDiaryCommand);

--- a/src/test/java/com/woodada/core/diary/domain/DiaryTest.java
+++ b/src/test/java/com/woodada/core/diary/domain/DiaryTest.java
@@ -1,5 +1,6 @@
 package com.woodada.core.diary.domain;
 
+import com.woodada.support.Deleted;
 import java.time.LocalDateTime;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +15,7 @@ public class DiaryTest {
     @ParameterizedTest
     @NullAndEmptySource
     void given_title_length_less_than_1_when_modify_then_throw_exception(String title) {
-        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
+        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", Deleted.FALSE, 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
 
         Assertions.assertThatThrownBy(() -> diary.modify(title, "수정 후 본문"))
             .isInstanceOf(IllegalArgumentException.class)
@@ -25,7 +26,7 @@ public class DiaryTest {
     @ParameterizedTest
     @NullAndEmptySource
     void given_contents_length_less_than_1_when_modify_then_throw_exception(String contents) {
-        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
+        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", Deleted.FALSE, 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
 
         Assertions.assertThatThrownBy(() -> diary.modify("수정 후 제목", contents))
             .isInstanceOf(IllegalArgumentException.class)
@@ -35,7 +36,7 @@ public class DiaryTest {
     @DisplayName("한 글자 이상의 제목과 본문을 전달하면 일기를 수정할 수 있다.")
     @Test
     void given_title_and_contents_greater_than_or_equal_to_1_when_modify_then_success() {
-        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
+        Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", Deleted.FALSE, 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
 
         diary.modify("제목", "본문");
 

--- a/src/test/java/com/woodada/core/diary/domain/DiaryTest.java
+++ b/src/test/java/com/woodada/core/diary/domain/DiaryTest.java
@@ -1,8 +1,10 @@
 package com.woodada.core.diary.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.woodada.support.Deleted;
 import java.time.LocalDateTime;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,7 +19,7 @@ public class DiaryTest {
     void given_title_length_less_than_1_when_modify_then_throw_exception(String title) {
         Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", Deleted.FALSE, 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
 
-        Assertions.assertThatThrownBy(() -> diary.modify(title, "수정 후 본문"))
+        assertThatThrownBy(() -> diary.modify(title, "수정 후 본문"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("수정할 제목을 한 글자 이상 입력해 주세요.");
     }
@@ -28,7 +30,7 @@ public class DiaryTest {
     void given_contents_length_less_than_1_when_modify_then_throw_exception(String contents) {
         Diary diary = Diary.withId(1L, "수정 전 제목", "수정 전 본문", Deleted.FALSE, 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
 
-        Assertions.assertThatThrownBy(() -> diary.modify("수정 후 제목", contents))
+        assertThatThrownBy(() -> diary.modify("수정 후 제목", contents))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("수정할 본문을 한 글자 이상 입력해 주세요.");
     }
@@ -40,7 +42,16 @@ public class DiaryTest {
 
         diary.modify("제목", "본문");
 
-        Assertions.assertThat(diary.getTitle()).isEqualTo("제목");
-        Assertions.assertThat(diary.getContents()).isEqualTo("본문");
+        assertThat(diary.getTitle()).isEqualTo("제목");
+        assertThat(diary.getContents()).isEqualTo("본문");
+    }
+
+    @DisplayName("삭제를 요청하면 삭제 여부 필드가 TRUE가 된다.")
+    @Test
+    void when_delete_then_deleted_changed_to_true() {
+        Diary diary = Diary.withId(1L, "제목", "본문", Deleted.FALSE, 1L, LocalDateTime.now(), 1L, LocalDateTime.now());
+        diary.delete();
+
+        assertThat(diary.getDeleted()).isEqualTo(Deleted.TRUE);
     }
 }


### PR DESCRIPTION
## 📍 이슈 번호
#35 

## 📚 작업 내용
- 일기 삭제 api 구현 및 테스트 코드 추가
- BaseEntity에 인자가 있는 생성자 추가